### PR TITLE
fix: タグの属性値に=が含まれる場合に正しくハイライトされないのを修正

### DIFF
--- a/syntaxes/tyrano.tmLanguage.json
+++ b/syntaxes/tyrano.tmLanguage.json
@@ -197,7 +197,7 @@
 			"patterns": [
 				{
 					"comment": "parameterあり  (\\S*)(\\s+(\\S*)=(S*))+",
-					"match":"(\\S*)(\\s*(\\S*)=(S*))+",
+					"match":"(\\S*)(\\s*(\\S*?)=(S*))+",
 					"captures": {
 						"1":{"patterns":[
 							{

--- a/syntaxes/tyrano.tmLanguage.json
+++ b/syntaxes/tyrano.tmLanguage.json
@@ -197,7 +197,7 @@
 			"patterns": [
 				{
 					"comment": "parameterあり  (\\S*)(\\s+(\\S*)=(S*))+",
-					"match":"(\\S*)(\\s*(\\S*?)=(S*))+",
+					"match":"(\\S*)(\\s+(\\S*?)=(S*))+",
 					"captures": {
 						"1":{"patterns":[
 							{


### PR DESCRIPTION
```
[if exp="tf.is_cg_open==true"]
```

のように属性値にスペースが現れる前に `=` があると、正しくハイライトされなくなります。

```
"match":"(\\S*)(\\s*(\\S*)=(S*))+",
```
の三つ目のキャプチャーが最短マッチになっていないため、途中の `=` を含めてマッチしてしまうためです。
本 PR では以下のように最短マッチを行うよう修正しています。

```
"match":"(\\S*)(\\s+(\\S*?)=(S*))+",
```

追記:

属性の前の空白文字が0個以上になっていたのを合わせて修正しました。