### PR TITLE
refactor: いくつかの `Provider` の型エラーを除去

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,4 +10,9 @@ out/
 .vscode
 language-configuration*.json
 package.json
-src/
+/src/**/*
+!/src/subscriptions/TyranoCreateTagByShortcutKey.ts
+!/src/subscriptions/TyranoDefinitionProvider.ts
+!/src/subscriptions/TyranoPreview.ts
+!/src/subscriptions/TyranoReferenceProvider.ts
+!/src/subscriptions/TyranoRenameProvider.ts

--- a/src/subscriptions/TyranoCreateTagByShortcutKey.ts
+++ b/src/subscriptions/TyranoCreateTagByShortcutKey.ts
@@ -1,13 +1,14 @@
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
 export class TyranoCreateTagByShortcutKey {
-
   /**
    * shift + Enterで実行されるコマンド
    * @returns true:正常終了 else:異常終了
    */
   KeyPushShiftEnter(): boolean {
-    const text: string | undefined = vscode.workspace.getConfiguration().get('TyranoScript syntax.keyboard.shift + enter');
+    const text: string | undefined = vscode.workspace
+      .getConfiguration()
+      .get("TyranoScript syntax.keyboard.shift + enter");
     const editor = vscode.window.activeTextEditor;
     if (editor != undefined) {
       const cursorPos = editor.selection.active;
@@ -17,10 +18,14 @@ export class TyranoCreateTagByShortcutKey {
         });
         return true;
       } else {
-        vscode.window.showInformationMessage("CreateTagByShortcutKey KeyPushShiftEnter ERROR1!!");
+        vscode.window.showInformationMessage(
+          "CreateTagByShortcutKey KeyPushShiftEnter ERROR1!!",
+        );
       }
     } else {
-      vscode.window.showInformationMessage("CreateTagByShortcutKey KeyPushShiftEnter ERROR2!!");
+      vscode.window.showInformationMessage(
+        "CreateTagByShortcutKey KeyPushShiftEnter ERROR2!!",
+      );
     }
     return false;
   }
@@ -30,7 +35,9 @@ export class TyranoCreateTagByShortcutKey {
    * @returns true:正常終了 else:異常終了
    */
   KeyPushCtrlEnter(): boolean {
-    const text: string | undefined = vscode.workspace.getConfiguration().get('TyranoScript syntax.keyboard.ctrl + enter(cmd + enter)');
+    const text: string | undefined = vscode.workspace
+      .getConfiguration()
+      .get("TyranoScript syntax.keyboard.ctrl + enter(cmd + enter)");
     const editor = vscode.window.activeTextEditor;
     if (editor != undefined) {
       const cursorPos = editor.selection.active;
@@ -40,10 +47,14 @@ export class TyranoCreateTagByShortcutKey {
         });
         return true;
       } else {
-        vscode.window.showInformationMessage("CreateTagByShortcutKey KeyPushCtrlEnter ERROR1!!");
+        vscode.window.showInformationMessage(
+          "CreateTagByShortcutKey KeyPushCtrlEnter ERROR1!!",
+        );
       }
     } else {
-      vscode.window.showInformationMessage("CreateTagByShortcutKey KeyPushCtrlEnter ERROR2!!");
+      vscode.window.showInformationMessage(
+        "CreateTagByShortcutKey KeyPushCtrlEnter ERROR2!!",
+      );
     }
     return false;
   }
@@ -53,7 +64,9 @@ export class TyranoCreateTagByShortcutKey {
    * @returns true:正常終了 else:異常終了
    */
   KeyPushAltEnter(): boolean {
-    const text: string | undefined = vscode.workspace.getConfiguration().get('TyranoScript syntax.keyboard.alt + enter(option + enter)');
+    const text: string | undefined = vscode.workspace
+      .getConfiguration()
+      .get("TyranoScript syntax.keyboard.alt + enter(option + enter)");
     const editor = vscode.window.activeTextEditor;
     if (editor != undefined) {
       const cursorPos = editor.selection.active;
@@ -63,12 +76,15 @@ export class TyranoCreateTagByShortcutKey {
         });
         return true;
       } else {
-        vscode.window.showInformationMessage("CreateTagByShortcutKey KeyPushAltEnter ERROR1!!");
+        vscode.window.showInformationMessage(
+          "CreateTagByShortcutKey KeyPushAltEnter ERROR1!!",
+        );
       }
     } else {
-      vscode.window.showInformationMessage("CreateTagByShortcutKey KeyPushAltEnter ERROR2!!");
+      vscode.window.showInformationMessage(
+        "CreateTagByShortcutKey KeyPushAltEnter ERROR2!!",
+      );
     }
     return false;
   }
 }
-

--- a/src/subscriptions/TyranoCreateTagByShortcutKey.ts
+++ b/src/subscriptions/TyranoCreateTagByShortcutKey.ts
@@ -10,7 +10,7 @@ export class TyranoCreateTagByShortcutKey {
     const text: string | undefined = vscode.workspace.getConfiguration().get('TyranoScript syntax.keyboard.shift + enter');
     const editor = vscode.window.activeTextEditor;
     if (editor != undefined) {
-      let cursorPos = editor.selection.active;
+      const cursorPos = editor.selection.active;
       if (text != undefined) {
         editor.edit((editbuilder) => {
           editbuilder.insert(cursorPos, text);
@@ -33,7 +33,7 @@ export class TyranoCreateTagByShortcutKey {
     const text: string | undefined = vscode.workspace.getConfiguration().get('TyranoScript syntax.keyboard.ctrl + enter(cmd + enter)');
     const editor = vscode.window.activeTextEditor;
     if (editor != undefined) {
-      let cursorPos = editor.selection.active;
+      const cursorPos = editor.selection.active;
       if (text != undefined) {
         editor.edit((editbuilder) => {
           editbuilder.insert(cursorPos, text);
@@ -56,7 +56,7 @@ export class TyranoCreateTagByShortcutKey {
     const text: string | undefined = vscode.workspace.getConfiguration().get('TyranoScript syntax.keyboard.alt + enter(option + enter)');
     const editor = vscode.window.activeTextEditor;
     if (editor != undefined) {
-      let cursorPos = editor.selection.active;
+      const cursorPos = editor.selection.active;
       if (text != undefined) {
         editor.edit((editbuilder) => {
           editbuilder.insert(cursorPos, text);

--- a/src/subscriptions/TyranoDefinitionProvider.ts
+++ b/src/subscriptions/TyranoDefinitionProvider.ts
@@ -9,7 +9,7 @@ import { Parser } from '../Parser';
 export class TyranoDefinitionProvider {
 
   private infoWs = InformationWorkSpace.getInstance();
-  private parser: Parser = Parser.getInstance();
+  private parser = Parser.getInstance();
   constructor() {
 
   }
@@ -24,11 +24,12 @@ export class TyranoDefinitionProvider {
    * @return A definition or a thenable that resolves to such. The lack of a result can be
    * signaled by returning `undefined` or `null`.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Definition | vscode.LocationLink[] | null | undefined> {
 
     const projectPath = await this.infoWs.getProjectPathByFilePath(document.uri.fsPath);
     const parsedData = this.parser.parseText(document.lineAt(position.line).text);
-    const tagIndex: number = this.parser.getIndex(parsedData, position.character);
+    const tagIndex = this.parser.getIndex(parsedData, position.character);
     //カーソル位置のマクロのMapデータ取得
     const retMacroData = this.infoWs.defineMacroMap.get(projectPath)?.get(parsedData[tagIndex]["name"]);
 

--- a/src/subscriptions/TyranoDefinitionProvider.ts
+++ b/src/subscriptions/TyranoDefinitionProvider.ts
@@ -1,19 +1,14 @@
-
-import * as vscode from 'vscode';
-import { InformationWorkSpace } from '../InformationWorkSpace';
-import { Parser } from '../Parser';
+import * as vscode from "vscode";
+import { InformationWorkSpace } from "../InformationWorkSpace";
+import { Parser } from "../Parser";
 
 /**
  * F12押したタグの定義元へジャンプするクラスです。
  */
 export class TyranoDefinitionProvider {
-
-  private infoWs = InformationWorkSpace.getInstance();
-  private parser = Parser.getInstance();
-  constructor() {
-
-  }
-
+  private readonly infoWs = InformationWorkSpace.getInstance();
+  private readonly parser = Parser.getInstance();
+  constructor() {}
 
   /**
    * Provide the definition of the symbol at the given position and document.
@@ -24,17 +19,24 @@ export class TyranoDefinitionProvider {
    * @return A definition or a thenable that resolves to such. The lack of a result can be
    * signaled by returning `undefined` or `null`.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Definition | vscode.LocationLink[] | null | undefined> {
 
-    const projectPath = await this.infoWs.getProjectPathByFilePath(document.uri.fsPath);
-    const parsedData = this.parser.parseText(document.lineAt(position.line).text);
+  async provideDefinition(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken, // eslint-disable-line @typescript-eslint/no-unused-vars
+  ): Promise<vscode.Definition | vscode.LocationLink[] | null | undefined> {
+    const projectPath = await this.infoWs.getProjectPathByFilePath(
+      document.uri.fsPath,
+    );
+    const parsedData = this.parser.parseText(
+      document.lineAt(position.line).text,
+    );
     const tagIndex = this.parser.getIndex(parsedData, position.character);
     //カーソル位置のマクロのMapデータ取得
-    const retMacroData = this.infoWs.defineMacroMap.get(projectPath)?.get(parsedData[tagIndex]["name"]);
+    const retMacroData = this.infoWs.defineMacroMap
+      .get(projectPath)
+      ?.get(parsedData[tagIndex]["name"]);
 
     return retMacroData?.location;
   }
-
-
 }

--- a/src/subscriptions/TyranoPreview.ts
+++ b/src/subscriptions/TyranoPreview.ts
@@ -1,12 +1,11 @@
-import * as vscode from 'vscode';
-import express from 'express';
+import * as vscode from "vscode";
+import express from "express";
 
-import { InformationWorkSpace } from '../InformationWorkSpace';
-import { previewPanel } from '../extension';
-import { TyranoLogger } from '../TyranoLogger';
+import { InformationWorkSpace } from "../InformationWorkSpace";
+import { previewPanel } from "../extension";
+import { TyranoLogger } from "../TyranoLogger";
 
 export class TyranoPreview {
-
   public static async createWindow() {
     if (!vscode.window.activeTextEditor) {
       return;
@@ -17,41 +16,48 @@ export class TyranoPreview {
         const app = express();
         console.log("preview");
         const infoWs = InformationWorkSpace.getInstance();
-        const filePath = await infoWs.getProjectPathByFilePath(vscode.window.activeTextEditor!.document.fileName);
-        app.use(express.static((filePath)));
-        app.listen(3100, () => { });
+        const filePath = await infoWs.getProjectPathByFilePath(
+          vscode.window.activeTextEditor!.document.fileName,
+        );
+        app.use(express.static(filePath));
+        app.listen(3100, () => {});
       } catch (error) {
         TyranoLogger.printStackTrace(error);
       }
-
-
-    }
-    const createPreview = async (previewPanel: vscode.WebviewPanel | undefined) => {
-      const create = ((previewPanel: vscode.WebviewPanel | undefined) => {
+    };
+    const createPreview = async (
+      previewPanel: vscode.WebviewPanel | undefined,
+    ) => {
+      const create = (previewPanel: vscode.WebviewPanel | undefined) => {
         previewPanel = vscode.window.createWebviewPanel(
-          'tyranoPreview',
-          'TyranoPreview',
-          vscode.ViewColumn.Two, {
-          enableScripts: true,//コンテンツスクリプトを有効化
-          retainContextWhenHidden: true,//非表示時にコンテンツスクリプトを維持
-          enableCommandUris: true,
-          portMapping: [{ webviewPort: 3100, extensionHostPort: 3100 }]
-        });
+          "tyranoPreview",
+          "TyranoPreview",
+          vscode.ViewColumn.Two,
+          {
+            enableScripts: true, //コンテンツスクリプトを有効化
+            retainContextWhenHidden: true, //非表示時にコンテンツスクリプトを維持
+            enableCommandUris: true,
+            portMapping: [{ webviewPort: 3100, extensionHostPort: 3100 }],
+          },
+        );
         previewPanel.webview.html = `
         <iframe src="http://localhost:3100/index.html" frameborder="0" style="width:100%; height:100vh;"></iframe>
-        `
-      });
+        `;
+      };
       const run = async () => {
-        await vscode.window.withProgress({
-          location: vscode.ProgressLocation.Notification,
-          title: "プレビューの作成中...",
-          cancellable: true
-        }, async (_progress, _token) => {
-          create(previewPanel);
-        });
-      }
+        await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: "プレビューの作成中...",
+            cancellable: true,
+          },
+          async (_progress, _token) => {
+            create(previewPanel);
+          },
+        );
+      };
       await run();
-    }
+    };
 
     createServer();
     createPreview(previewPanel);

--- a/src/subscriptions/TyranoPreview.ts
+++ b/src/subscriptions/TyranoPreview.ts
@@ -1,10 +1,7 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
-import * as fs from 'fs';
-const express = require('express');
+import express from 'express';
 
 import { InformationWorkSpace } from '../InformationWorkSpace';
-import { InformationExtension } from '../InformationExtension';
 import { previewPanel } from '../extension';
 import { TyranoLogger } from '../TyranoLogger';
 
@@ -49,7 +46,7 @@ export class TyranoPreview {
           location: vscode.ProgressLocation.Notification,
           title: "プレビューの作成中...",
           cancellable: true
-        }, async (progress, token) => {
+        }, async (_progress, _token) => {
           create(previewPanel);
         });
       }

--- a/src/subscriptions/TyranoReferenceProvider.ts
+++ b/src/subscriptions/TyranoReferenceProvider.ts
@@ -1,18 +1,19 @@
-
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
 export class TyranoReferenceProvider {
+  constructor() {}
 
-  constructor() {
-
-  }
-
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  provideReferences(document: vscode.TextDocument, position: vscode.Position, context: vscode.ReferenceContext, token: vscode.CancellationToken): vscode.Location[] | null | undefined {
+  provideReferences(
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    context: vscode.ReferenceContext,
+    token: vscode.CancellationToken,
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+  ): vscode.Location[] | null | undefined {
     // console.log("provideReference");
     // console.log(`document:${document.fileName}\nposition:${position.line}\ncontext:${context}\ntoken:${token}\n`);
 
-    return null;//未定義の場合null
+    return null; //未定義の場合null
   }
 }

--- a/src/subscriptions/TyranoReferenceProvider.ts
+++ b/src/subscriptions/TyranoReferenceProvider.ts
@@ -8,6 +8,7 @@ export class TyranoReferenceProvider {
   }
 
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   provideReferences(document: vscode.TextDocument, position: vscode.Position, context: vscode.ReferenceContext, token: vscode.CancellationToken): vscode.Location[] | null | undefined {
     // console.log("provideReference");
     // console.log(`document:${document.fileName}\nposition:${position.line}\ncontext:${context}\ntoken:${token}\n`);

--- a/src/subscriptions/TyranoRenameProvider.ts
+++ b/src/subscriptions/TyranoRenameProvider.ts
@@ -18,6 +18,7 @@ export class TyranoRenameProvider {
    * @return A workspace edit or a thenable that resolves to such. The lack of a result can be
    * signaled by returning `undefined` or `null`.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   provideRenameEdits(document: vscode.TextDocument, position: vscode.Position, newName: string, token: vscode.CancellationToken): vscode.WorkspaceEdit | null | undefined {
     // console.log("provideRenameEdits");
     // console.log(`document:${document.fileName}\nposition:${position.line}\nnewName:${newName}\ntoken:${token}\n`);

--- a/src/subscriptions/TyranoRenameProvider.ts
+++ b/src/subscriptions/TyranoRenameProvider.ts
@@ -2,10 +2,7 @@
 import * as vscode from 'vscode';
 
 export class TyranoRenameProvider {
-
-  constructor() {
-
-  }
+  constructor() {}
 
   /**
    * Provide an edit that describes changes that have to be made to one
@@ -18,12 +15,17 @@ export class TyranoRenameProvider {
    * @return A workspace edit or a thenable that resolves to such. The lack of a result can be
    * signaled by returning `undefined` or `null`.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  provideRenameEdits(document: vscode.TextDocument, position: vscode.Position, newName: string, token: vscode.CancellationToken): vscode.WorkspaceEdit | null | undefined {
+  provideRenameEdits(
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    newName: string,
+    token: vscode.CancellationToken,
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+  ): vscode.WorkspaceEdit | null | undefined {
     // console.log("provideRenameEdits");
     // console.log(`document:${document.fileName}\nposition:${position.line}\nnewName:${newName}\ntoken:${token}\n`);
 
     return null;
   }
-
 }


### PR DESCRIPTION
## 概要

いくつかの `Provider` をリファクタリングし、`prettier` を使用してフォーマットしました。

- 変数が変更されない場合、`let` を `const` に置き換えました。
- 不要な型注釈（例：`const text: string = ((...): string => {...})(...)`）を削除しました。
- `import` 文を調整しました。

※ #162 の一部として

<details>

<summary>
In English::
</summary>

## Abstract

Refactored providers and formatted them using `prettier`.

- Replaced `let` to `const` if the variable is not modified;
- Removed unnecessary type annotations such as `const text: string = ((...): string => {...})(...)`;
- Tweaked `import`-statements;

As a part of `#162`

<details>
