### PR TITLE
refactor: `TyranoOutlineProvider` の型エラーを削除

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,7 @@ package.json
 !/src/subscriptions/TyranoCompletionItemProvider.ts
 !/src/subscriptions/TyranoCreateTagByShortcutKey.ts
 !/src/subscriptions/TyranoDefinitionProvider.ts
+!/src/subscriptions/TyranoOutlineProvider.ts
 !/src/subscriptions/TyranoPreview.ts
 !/src/subscriptions/TyranoReferenceProvider.ts
 !/src/subscriptions/TyranoRenameProvider.ts

--- a/src/subscriptions/TyranoOutlineProvider.ts
+++ b/src/subscriptions/TyranoOutlineProvider.ts
@@ -7,13 +7,13 @@ export class TyranoOutlineProvider implements vscode.DocumentSymbolProvider {
   constructor() {
   }
 
-  public provideDocumentSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.DocumentSymbol[] | vscode.SymbolInformation[]> {
+  public provideDocumentSymbols(document: vscode.TextDocument, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.DocumentSymbol[] | vscode.SymbolInformation[]> {
 
-    let symbols = [];
+    const symbols = [];
     let commentFlag: boolean = false; //複数行コメントになっているかのフラグ
 
     for (let i = 0; i < document.lineCount; i++) {
-      let line = document.lineAt(i);//i行目のドキュメントを取得
+      const line = document.lineAt(i);//i行目のドキュメントを取得
 
       //ブロックコメント中ならアウトラインとして表示しない(β機能)
       //FIXME: 「hoge /**/」とか「/**/ hoge」のような書き方をすると正しくアウトラインに表示されない。
@@ -35,21 +35,21 @@ export class TyranoOutlineProvider implements vscode.DocumentSymbolProvider {
 
       //タグのアウトライン表示
       if (this.isAddTagOutline(line.text)) {
-        let symbol = new vscode.DocumentSymbol(line.text, 'Component', vscode.SymbolKind.Class, line.range, line.range);
+        const symbol = new vscode.DocumentSymbol(line.text, 'Component', vscode.SymbolKind.Class, line.range, line.range);
         symbols.push(symbol);
       }
 
       //変数のアウトライン表示
       if (this.isAddVariableOutLine(line.text)) {
-        const outlineText: string | null = line.text.match(this.REGEX_VARIABLE)![0];
-        let symbol = new vscode.DocumentSymbol(outlineText, 'Component', vscode.SymbolKind.Variable, line.range, line.range);
+        const outlineText = line.text.match(this.REGEX_VARIABLE)![0];
+        const symbol = new vscode.DocumentSymbol(outlineText, 'Component', vscode.SymbolKind.Variable, line.range, line.range);
         symbols.push(symbol);
       }
 
 
       //ラベルをアウトラインに表示
       if (this.isAddLabelOutLine(line.text)) {
-        let symbol = new vscode.DocumentSymbol(line.text, 'Component', vscode.SymbolKind.Function, line.range, line.range);
+        const symbol = new vscode.DocumentSymbol(line.text, 'Component', vscode.SymbolKind.Function, line.range, line.range);
         symbols.push(symbol);
       }
     }

--- a/src/subscriptions/TyranoOutlineProvider.ts
+++ b/src/subscriptions/TyranoOutlineProvider.ts
@@ -1,24 +1,31 @@
-import * as vscode from 'vscode';
-
+import * as vscode from "vscode";
 
 export class TyranoOutlineProvider implements vscode.DocumentSymbolProvider {
-  private readonly REGEX_VARIABLE = /\b(f\.|sf\.|tf\.|mp\.)([a-zA-Z_ぁ-んァ-ヶ一-龠Ａ-Ｚａ-ｚ]+)(([0-9a-zA-Z_ぁ-んァ-ヶ一-龠０-９Ａ-Ｚａ-ｚ]*))\b/;//変数検出用のアウトライン
-  constructor() {
-  }
+  private readonly REGEX_VARIABLE =
+    /\b(f\.|sf\.|tf\.|mp\.)([a-zA-Z_ぁ-んァ-ヶ一-龠Ａ-Ｚａ-ｚ]+)(([0-9a-zA-Z_ぁ-んァ-ヶ一-龠０-９Ａ-Ｚａ-ｚ]*))\b/; //変数検出用のアウトライン
+  constructor() {}
 
-  public provideDocumentSymbols(document: vscode.TextDocument, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.DocumentSymbol[] | vscode.SymbolInformation[]> {
-
+  public provideDocumentSymbols(
+    document: vscode.TextDocument,
+    _token: vscode.CancellationToken,
+  ): vscode.ProviderResult<
+    vscode.DocumentSymbol[] | vscode.SymbolInformation[]
+  > {
     const symbols = [];
     let commentFlag: boolean = false; //複数行コメントになっているかのフラグ
 
     for (let i = 0; i < document.lineCount; i++) {
-      const line = document.lineAt(i);//i行目のドキュメントを取得
+      const line = document.lineAt(i); //i行目のドキュメントを取得
 
       //ブロックコメント中ならアウトラインとして表示しない(β機能)
       //FIXME: 「hoge /**/」とか「/**/ hoge」のような書き方をすると正しくアウトラインに表示されない。
       //解決策１：regExpの正規表現を変えて、/**/[p]のような書き方でも正しく正規表現されるようにする
       //解決策２：ブロックコメント内のアウトライン検出アルゴリズムを変える。
-      if (vscode.workspace.getConfiguration().get('TyranoScript syntax.outline.blockComment')) {
+      if (
+        vscode.workspace
+          .getConfiguration()
+          .get("TyranoScript syntax.outline.blockComment")
+      ) {
         if (line.text.includes("/*")) {
           commentFlag = true;
         }
@@ -34,28 +41,43 @@ export class TyranoOutlineProvider implements vscode.DocumentSymbolProvider {
 
       //タグのアウトライン表示
       if (this.isAddTagOutline(line.text)) {
-        const symbol = new vscode.DocumentSymbol(line.text, 'Component', vscode.SymbolKind.Class, line.range, line.range);
+        const symbol = new vscode.DocumentSymbol(
+          line.text,
+          "Component",
+          vscode.SymbolKind.Class,
+          line.range,
+          line.range,
+        );
         symbols.push(symbol);
       }
 
       //変数のアウトライン表示
       if (this.isAddVariableOutLine(line.text)) {
         const outlineText = line.text.match(this.REGEX_VARIABLE)![0];
-        const symbol = new vscode.DocumentSymbol(outlineText, 'Component', vscode.SymbolKind.Variable, line.range, line.range);
+        const symbol = new vscode.DocumentSymbol(
+          outlineText,
+          "Component",
+          vscode.SymbolKind.Variable,
+          line.range,
+          line.range,
+        );
         symbols.push(symbol);
       }
 
-
       //ラベルをアウトラインに表示
       if (this.isAddLabelOutLine(line.text)) {
-        const symbol = new vscode.DocumentSymbol(line.text, 'Component', vscode.SymbolKind.Function, line.range, line.range);
+        const symbol = new vscode.DocumentSymbol(
+          line.text,
+          "Component",
+          vscode.SymbolKind.Function,
+          line.range,
+          line.range,
+        );
         symbols.push(symbol);
       }
     }
     return symbols;
   }
-
-
 
   /**
    * 引数で渡した文字列に、アウトライン表示するタグが含まれているかを判定します。
@@ -63,9 +85,11 @@ export class TyranoOutlineProvider implements vscode.DocumentSymbolProvider {
    * @returns アウトライン表示するタグが含まれているならtrue,そうでないならfalse
    */
   private isAddTagOutline(text: string): boolean {
-    const REGEX = /((\w+))\s*((\S*)=\"?(\w*)\"?)*()/;//タグ検出用の正規表現
-    const MATCH_TEXT = text.match(REGEX);//[hoge param=""]の形式のタグでマッチしてるかを探して変数に格納
-    const OUTLINE_TAG: string[] | undefined = vscode.workspace.getConfiguration().get('TyranoScript syntax.outline.tag');//setting.jsonに記載のタグ取得
+    const REGEX = /((\w+))\s*((\S*)=\"?(\w*)\"?)*()/; //タグ検出用の正規表現
+    const MATCH_TEXT = text.match(REGEX); //[hoge param=""]の形式のタグでマッチしてるかを探して変数に格納
+    const OUTLINE_TAG: string[] | undefined = vscode.workspace
+      .getConfiguration()
+      .get("TyranoScript syntax.outline.tag"); //setting.jsonに記載のタグ取得
     let matchText: string = "";
 
     // タグとマッチしないなら戻る
@@ -97,7 +121,6 @@ export class TyranoOutlineProvider implements vscode.DocumentSymbolProvider {
     return false;
   }
 
-
   /**
    * 引数で渡した文字列に、アウトライン表示するラベルが含まれているかを判定します。
    * @param text その行の文字列
@@ -105,13 +128,11 @@ export class TyranoOutlineProvider implements vscode.DocumentSymbolProvider {
    */
   private isAddLabelOutLine(text: string): boolean {
     //ラベルをアウトラインに表示
-    const REGEX = /^\*[0-9a-zA-Z\\-_]+/;//ラベル検出用正規表現
+    const REGEX = /^\*[0-9a-zA-Z\\-_]+/; //ラベル検出用正規表現
 
     if (text.search(REGEX) !== -1) {
       return true;
     }
     return false;
   }
-
 }
-

--- a/src/subscriptions/TyranoOutlineProvider.ts
+++ b/src/subscriptions/TyranoOutlineProvider.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 
 
 export class TyranoOutlineProvider implements vscode.DocumentSymbolProvider {
-  MATCH_TEXTS: Array<string> | undefined;
   private readonly REGEX_VARIABLE = /\b(f\.|sf\.|tf\.|mp\.)([a-zA-Z_ぁ-んァ-ヶ一-龠Ａ-Ｚａ-ｚ]+)(([0-9a-zA-Z_ぁ-んァ-ヶ一-龠０-９Ａ-Ｚａ-ｚ]*))\b/;//変数検出用のアウトライン
   constructor() {
   }

--- a/src/subscriptions/TyranoOutlineProvider.ts
+++ b/src/subscriptions/TyranoOutlineProvider.ts
@@ -85,28 +85,23 @@ export class TyranoOutlineProvider implements vscode.DocumentSymbolProvider {
    * @returns アウトライン表示するタグが含まれているならtrue,そうでないならfalse
    */
   private isAddTagOutline(text: string): boolean {
-    const REGEX = /((\w+))\s*((\S*)=\"?(\w*)\"?)*()/; //タグ検出用の正規表現
-    const MATCH_TEXT = text.match(REGEX); //[hoge param=""]の形式のタグでマッチしてるかを探して変数に格納
-    const OUTLINE_TAG: string[] | undefined = vscode.workspace
+    const outlineTags: string[] | undefined = vscode.workspace
       .getConfiguration()
       .get("TyranoScript syntax.outline.tag"); //setting.jsonに記載のタグ取得
-    let matchText: string = "";
-
-    // タグとマッチしないなら戻る
-    if (!MATCH_TEXT) {
+    if (!outlineTags) {
       return false;
     }
-    matchText = MATCH_TEXT[1];
 
-    //matchTextがMATCH_TEXTSで定義したいずれかのタグがあるならアウトラインに表示
-    if (OUTLINE_TAG !== undefined) {
-      for (let j = 0; j < OUTLINE_TAG.length; j++) {
-        if (matchText === OUTLINE_TAG[j]) {
-          return true;
-        }
-      }
+    const REGEX = /((\w+))\s*((\S*)="?(\w*)"?)*()/; //タグ検出用の正規表現
+    const matcher = text.match(REGEX); //[hoge param=""]の形式のタグでマッチしてるかを探して変数に格納
+    // タグとマッチしないなら戻る
+    if (!matcher) {
+      return false;
     }
-    return false;
+
+    const tagName = matcher[1];
+
+    return outlineTags.includes(tagName);
   }
 
   /**


### PR DESCRIPTION
## 概要

`TyranoOutlineProvider` をリファクタリングし、`prettier` を使用してフォーマットしました。

- 変数が変更されない場合、`let` を `const` に置き換えました。
- `import` 文を調整しました。

※ #162 の一部として

<details>

<summary>
In English::
</summary>

## Abstract

Refactored `TyranoOutlineProvider` and formatted it using `prettier`.

- Replaced `let` to `const` if the variable is not modified;
- Tweaked `import`-statements;

As a part of `#162`

<details>
