### PR TITLE
KAG タグは KAG HTML ブロック内の HTML タグに含めることができる

### DIFF
--- a/syntaxes/tyrano.tmLanguage.json
+++ b/syntaxes/tyrano.tmLanguage.json
@@ -138,14 +138,14 @@
       },
       "patterns": [
         {
-          "patterns": [
-            {
-              "include": "$self"
-            }
-          ]
+          "include": "text.html.basic"
         },
         {
-          "include": "text.html.basic"
+          "information_for_contributors": [
+            "The tag `html` might contain `source.ks source.tyrano`",
+            "See orukRed/tyranosyntax#139"
+          ],
+          "include": "$self"
         }
       ]
     },
@@ -176,7 +176,14 @@
       },
       "patterns": [
         {
-          "include": "source.js"
+          "include": "text.html.basic"
+        },
+        {
+          "information_for_contributors": [
+            "The tag `html` might contain `source.ks source.tyrano`",
+            "See orukRed/tyranosyntax#139"
+          ],
+          "include": "$self"
         }
       ]
     },


### PR DESCRIPTION
## 概要

KAG タグは KAG HTML ブロック内の HTML タグに含めることができる（参考： #139 ）。

## 期待される動作

`@html...@endhtml` と `[html]...[endhtml]` の両方のセットが同じように機能する。

## 実際の動作

`@html...@endhtml` と `[html]...[endhtml]` の両方のセットが同じように機能しない。

## 動作する例

![動作する例](https://github.com/user-attachments/assets/7920fbf0-2c63-4be8-9ec6-efed9074317e)

```kag
@html
[p]
<div>
[iscript]
[endscript]
</div>
@endhtml

[html]
[p]
<div>
[iscript]
[endscript]
</div>
[endhtml]
```

---

<details>

<summary>
In English
</summary>

## Summary

KAG tags can be included in HTML tags within KAG HTML blocks (see #139 ). 

## Expected Behavior

Both pairs of `@html...@endhtml` and `[html]...[endhtml]` should be highlighted identically.

## Actual Behavior

Both pairs of `@html...@endhtml` and `[html]...[endhtml]` weren't highlighted identically.

## Working Example

![](https://github.com/user-attachments/assets/7920fbf0-2c63-4be8-9ec6-efed9074317e)

```
@html
[p]
<div>
[iscript]
[endscript]
</div>
@endhtml

[html]
[p]
<div>
[iscript]
[endscript]
</div>
[endhtml]
```

</details>