### PR TITLE
fix: `region` と `endregion` がコメント行の外で無効にする

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -56,8 +56,8 @@
   "wordPattern": "[a-zA-Z0-9_/\\.]+",
   "folding": {
     "markers": {
-      "start": "^\\s*;?region\\b",
-      "end": "^\\s*;?endregion\\b"
+      "start": "^\\s*;+\\s*region\\b",
+      "end": "^\\s*;+\\s*endregion\\b"
     }
   }
 }


### PR DESCRIPTION
## 概要

region と endregion のペアがコメント行の外でも有効になっている

---

In English

## Summary 

The pair of `region` and `endregion` should be disabled outside a comment line.

## Examples

```
;## Applicable ##
;region
"This line can be folded"
;endregion

region
"This line can be folded"
endregion

;## Inapplicable ##
; region
"This line cannot be folded because spaces after `;` are not acceptable"
; endregion

;;region
"This line cannot be folded because two or more `;` are not acceptable"
;;endregion
```
