### PR TITLE
chore: `eslint-plugin-sonarjs` を導入して認知的複雑性を検証する

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 // https://eslint.org/
 import globals from "globals";
 import pluginJs from "@eslint/js";
+import sonarjs from "eslint-plugin-sonarjs";
 import tseslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier";
 
@@ -27,4 +28,10 @@ export default [
   },
   ...tseslint.configs.recommended,
   eslintConfigPrettier,
+  {
+    plugins: { sonarjs },
+    rules: {
+      "sonarjs/cognitive-complexity": "warn",
+    },
+  },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tyranosyntax",
-  "version": "0.24.0",
+  "version": "0.24.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tyranosyntax",
-      "version": "0.24.0",
+      "version": "0.24.9",
       "dependencies": {
         "@babel/parser": "^7.24.6",
         "@babel/traverse": "^7.24.6",
@@ -28,6 +28,7 @@
         "@vscode/test-electron": "^2.3.3",
         "eslint": "^8.43.0",
         "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-sonarjs": "^1.0.4",
         "glob": "^8.1.0",
         "globals": "^15.8.0",
         "mocha": "^9.2.2",
@@ -3191,6 +3192,19 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-1.0.4.tgz",
+      "integrity": "sha512-jF0eGCUsq/HzMub4ExAyD8x1oEgjOyB9XVytYGyWgSFvdiJQJp6IuP7RmtauCf06o6N/kZErh+zW4b10y1WZ+Q==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -935,6 +935,7 @@
     "@vscode/test-electron": "^2.3.3",
     "eslint": "^8.43.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-sonarjs": "^1.0.4",
     "glob": "^8.1.0",
     "globals": "^15.8.0",
     "mocha": "^9.2.2",


### PR DESCRIPTION
## 概要

リファクタリングするべきソースコードの優先度を見積もるため、認知的複雑性[^fn:cognitive-complexity]の検証を導入する

[^fn:cognitive-complexity]: コードの複雑さの指標。高いほど複雑である。（※ #154 を参照）

## 動作デモ

![問題タブ](https://github.com/user-attachments/assets/a15638ec-32de-437b-a424-646f1648cfb4)

## 関連リンク

- #154 