### PR TITLE
macroで定義したタグが補完できないときがある

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "tyranosyntax" extension will be documented in this f
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.25.1]- 2024-10-11
+
+`[macro]`タグでタグを定義したとき、頭にコメントアウトがないと正しく補完されない不具合を修正しました。
+
 ## [0.25.0]- 2024-10-05
 
 - 診断機能のONOFFを切り替えられるようにしました。

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/orukRed/tyranosyntax"
   },
   "icon": "images/icon.png",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "engines": {
     "vscode": "^1.79.1"
   },

--- a/src/subscriptions/TyranoCompletionItemProvider.ts
+++ b/src/subscriptions/TyranoCompletionItemProvider.ts
@@ -711,10 +711,13 @@ export class TyranoCompletionItemProvider
     ) as SuggestionsMiniumByTag; // FIXME: Don't use type assertion
 
     for (const suggestion of Object.values(suggestionsByTag)) {
-      if (!suggestion.name || !suggestion.description) continue;
+      if (!suggestion.name) continue;
       const { name, description } = suggestion;
       try {
-        // FIXME: Make the `try`-block smaller
+        // FIXME: Make the `try`-block smaller[]
+        if (name.indexOf("endreplay") !== -1) {
+          console.log("aaaa");
+        }
         const textLabel = name.toString();
         const comp = new vscode.CompletionItem(textLabel);
         const inputType = vscode.workspace


### PR DESCRIPTION
Fixes #212
descriptionが空だとcontinueしてしまっていたので、空でも補完できるようにしました。