### PR TITLE
feat: `*` から始まる行で `jump` 未定義ターゲットのラベル補完を追加 (#245)

### DIFF
--- a/src/defineData/TransitionData.ts
+++ b/src/defineData/TransitionData.ts
@@ -22,6 +22,10 @@ export class TransitionData {
   //上記のパラメータを定義したファイルパス
   private fileUri: vscode.Location | undefined;
 
+  public get targetLabel(): string | undefined {
+    return this.target;
+  }
+
   public constructor(
     tag: string,
     storage: string | undefined,
@@ -57,4 +61,3 @@ export class TransitionData {
     }
   }
 }
-

--- a/src/subscriptions/TyranoCompletionItemProvider.ts
+++ b/src/subscriptions/TyranoCompletionItemProvider.ts
@@ -444,17 +444,17 @@ export class TyranoCompletionItemProvider
   > {
     // プロジェクト内で定義済みのラベル名セットを構築
     const definedLabels = new Set<string>();
-    this.infoWs.labelMap.forEach(async (labels, filePath) => {
+    for (const [filePath, labels] of this.infoWs.labelMap) {
       const labelProjectPath =
         await this.infoWs.getProjectPathByFilePath(filePath);
       if (labelProjectPath === projectPath) {
         labels.forEach((label) => definedLabels.add(label.name));
       }
-    });
+    }
 
     // プロジェクト内のjump系タグで参照されているtargetラベル名を収集
     const referencedTargets = new Set<string>();
-    this.infoWs.transitionMap.forEach(async (transitions, filePath) => {
+    for (const [filePath, transitions] of this.infoWs.transitionMap) {
       const transitionProjectPath =
         await this.infoWs.getProjectPathByFilePath(filePath);
       if (transitionProjectPath === projectPath) {
@@ -468,7 +468,7 @@ export class TyranoCompletionItemProvider
           }
         });
       }
-    });
+    }
 
     // 未定義のターゲットのみを補完候補として返す
     const completions: vscode.CompletionItem[] = [];

--- a/src/subscriptions/TyranoCompletionItemProvider.ts
+++ b/src/subscriptions/TyranoCompletionItemProvider.ts
@@ -36,12 +36,12 @@ export class TyranoCompletionItemProvider
 {
   private infoWs = InformationWorkSpace.getInstance();
   private parser = Parser.getInstance();
-  
+
   // 正規表現を事前にコンパイルして再利用
   private readonly PARAM_REGEXP = new RegExp('(\\S)+="(?![\\s\\S]*")', "g");
   private readonly VARIABLE_REGEXP = /&?(f\.|sf\.|tf\.|mp\.)(\S)*$/;
   private readonly SHARP_REGEXP = /\s*#.*$/;
-  
+
   public constructor() {}
   private tagParams: {
     [s: string]: { [s: string]: TagParameterConfig };
@@ -152,8 +152,15 @@ export class TyranoCompletionItemProvider
       // //characterDataのlayerのキー（part）の配列を取得
       const layerParts = this.findLayerParts(projectPath, tagIndex, parsedData);
 
+      // *から始まる行（ラベル定義行）ならラベル補完を出す
+      if (/^[\t ]*\*/.test(lineText)) {
+        return await this.completionLabelDefinition(projectPath);
+      }
       //カーソルの左隣の文字取得
-      if (typeof leftSideText === "string" && this.SHARP_REGEXP.test(leftSideText)) {
+      if (
+        typeof leftSideText === "string" &&
+        this.SHARP_REGEXP.test(leftSideText)
+      ) {
         return await this.completionNameParameter(projectPath);
       } else if (variableValue) {
         const variableKind = variableValue[0].split(".")[0].replace("&", "");
@@ -422,6 +429,64 @@ export class TyranoCompletionItemProvider
 
     return completions;
   }
+  /**
+   * ラベル定義行（*から始まる行）でのインテリセンス。
+   * プロジェクト内のjump系タグで参照されているが、まだ定義されていないラベル名を候補として返す。
+   * @param projectPath
+   */
+  private async completionLabelDefinition(
+    projectPath: string,
+  ): Promise<
+    | vscode.CompletionItem[]
+    | vscode.CompletionList<vscode.CompletionItem>
+    | null
+    | undefined
+  > {
+    // プロジェクト内で定義済みのラベル名セットを構築
+    const definedLabels = new Set<string>();
+    this.infoWs.labelMap.forEach(async (labels, filePath) => {
+      const labelProjectPath =
+        await this.infoWs.getProjectPathByFilePath(filePath);
+      if (labelProjectPath === projectPath) {
+        labels.forEach((label) => definedLabels.add(label.name));
+      }
+    });
+
+    // プロジェクト内のjump系タグで参照されているtargetラベル名を収集
+    const referencedTargets = new Set<string>();
+    this.infoWs.transitionMap.forEach(async (transitions, filePath) => {
+      const transitionProjectPath =
+        await this.infoWs.getProjectPathByFilePath(filePath);
+      if (transitionProjectPath === projectPath) {
+        transitions.forEach((transition) => {
+          const target = transition.targetLabel;
+          if (target) {
+            // *付きで保存されている場合は除去して正規化
+            referencedTargets.add(
+              target.startsWith("*") ? target.slice(1) : target,
+            );
+          }
+        });
+      }
+    });
+
+    // 未定義のターゲットのみを補完候補として返す
+    const completions: vscode.CompletionItem[] = [];
+    referencedTargets.forEach((target) => {
+      if (!definedLabels.has(target)) {
+        const comp = new vscode.CompletionItem(target);
+        comp.kind = vscode.CompletionItemKind.Interface;
+        comp.insertText = target;
+        comp.detail = "未定義のjumpターゲット";
+        comp.documentation = new vscode.MarkdownString(
+          `jump/callタグで参照されているが、まだ定義されていないラベルです。`,
+        );
+        completions.push(comp);
+      }
+    });
+    return completions;
+  }
+
   /**
    * ラベルへのインテリセンス
    * @param projectPath

--- a/src/subscriptions/TyranoCompletionItemProvider.ts
+++ b/src/subscriptions/TyranoCompletionItemProvider.ts
@@ -462,9 +462,13 @@ export class TyranoCompletionItemProvider
           const target = transition.targetLabel;
           if (target) {
             // *付きで保存されている場合は除去して正規化
-            referencedTargets.add(
-              target.startsWith("*") ? target.slice(1) : target,
-            );
+            const normalized = target.startsWith("*")
+              ? target.slice(1)
+              : target;
+            // 変数参照（&を含む）はラベルではないため除外
+            if (!normalized.includes("&")) {
+              referencedTargets.add(normalized);
+            }
           }
         });
       }

--- a/src/test/suite/subscriptions/TyranoCompletionItemProvider.test.ts
+++ b/src/test/suite/subscriptions/TyranoCompletionItemProvider.test.ts
@@ -504,4 +504,244 @@ suite("TyranoCompletionItemProvider", () => {
       }
     });
   });
+
+  // ラベル定義行（*から始まる行）の補完テスト
+  suite("completionLabelDefinition", () => {
+    const PROJECT_PATH = "/project";
+
+    /** infoWs のモックを組み立てるヘルパー */
+    function makeInfoWsMock({
+      definedLabels,
+      referencedTargets,
+    }: {
+      definedLabels: string[];
+      referencedTargets: string[];
+    }) {
+      const labelMap = new Map<string, { name: string }[]>([
+        [
+          `${PROJECT_PATH}/data/scenario/first.ks`,
+          definedLabels.map((name) => ({ name })),
+        ],
+      ]);
+      const transitionMap = new Map<
+        string,
+        { targetLabel: string | undefined }[]
+      >([
+        [
+          `${PROJECT_PATH}/data/scenario/first.ks`,
+          referencedTargets.map((t) => ({ targetLabel: t })),
+        ],
+      ]);
+      return {
+        labelMap,
+        transitionMap,
+        getProjectPathByFilePath: async (_: string) => PROJECT_PATH,
+      };
+    }
+
+    test("正常系 jumpターゲットとして参照されているが未定義のラベルが候補に表示される", async () => {
+      const provider = new TyranoCompletionItemProvider();
+      const providerAny = provider as any;
+
+      providerAny.infoWs = makeInfoWsMock({
+        definedLabels: [],
+        referencedTargets: ["undefined_label"],
+      });
+
+      const result = await providerAny.completionLabelDefinition(PROJECT_PATH);
+
+      assert.ok(Array.isArray(result), "配列が返されるべき");
+      assert.strictEqual(result.length, 1, "1件の候補が返されるべき");
+      assert.strictEqual(
+        result[0].label,
+        "undefined_label",
+        "未定義ターゲット名が候補に含まれるべき",
+      );
+      assert.strictEqual(
+        result[0].kind,
+        vscode.CompletionItemKind.Interface,
+        "CompletionItemKind.Interfaceであるべき",
+      );
+    });
+
+    test("正常系 定義済みのラベルは補完候補から除外される", async () => {
+      const provider = new TyranoCompletionItemProvider();
+      const providerAny = provider as any;
+
+      providerAny.infoWs = makeInfoWsMock({
+        definedLabels: ["already_defined"],
+        referencedTargets: ["already_defined", "undefined_label"],
+      });
+
+      const result = await providerAny.completionLabelDefinition(PROJECT_PATH);
+
+      assert.ok(Array.isArray(result), "配列が返されるべき");
+      const labels = result.map((item: any) => item.label);
+      assert.ok(
+        !labels.includes("already_defined"),
+        "定義済みラベルは候補に含まれないべき",
+      );
+      assert.ok(
+        labels.includes("undefined_label"),
+        "未定義ラベルは候補に含まれるべき",
+      );
+    });
+
+    test("正常系 *付きで保存されたtargetも正規化して扱われる", async () => {
+      const provider = new TyranoCompletionItemProvider();
+      const providerAny = provider as any;
+
+      providerAny.infoWs = makeInfoWsMock({
+        definedLabels: [],
+        referencedTargets: ["*star_prefixed_label"],
+      });
+
+      const result = await providerAny.completionLabelDefinition(PROJECT_PATH);
+
+      assert.ok(Array.isArray(result), "配列が返されるべき");
+      assert.strictEqual(result.length, 1, "1件の候補が返されるべき");
+      assert.strictEqual(
+        result[0].label,
+        "star_prefixed_label",
+        "*を除いたラベル名が候補に表示されるべき",
+      );
+    });
+  });
+
+  // *から始まる行での provideCompletionItems ルーティングテスト
+  suite("*行でのラベル定義補完ルーティング", () => {
+    function makeMockDocumentWithLine(
+      lineText: string,
+    ): vscode.TextDocument {
+      return {
+        uri: vscode.Uri.file("/project/data/scenario/test.ks"),
+        fileName: "/project/data/scenario/test.ks",
+        isUntitled: false,
+        languageId: "tyrano",
+        version: 1,
+        isDirty: false,
+        isClosed: false,
+        eol: vscode.EndOfLine.LF,
+        lineCount: 1,
+        save: () => Promise.resolve(true),
+        lineAt: (_: number | vscode.Position) => ({
+          lineNumber: 0,
+          text: lineText,
+          range: new vscode.Range(0, 0, 0, lineText.length),
+          rangeIncludingLineBreak: new vscode.Range(0, 0, 1, 0),
+          firstNonWhitespaceCharacterIndex: lineText.search(/\S/),
+          isEmptyOrWhitespace: lineText.trim() === "",
+        }),
+        offsetAt: () => 0,
+        positionAt: () => new vscode.Position(0, 0),
+        getText: () => lineText,
+        getWordRangeAtPosition: () => undefined,
+        validateRange: (r: vscode.Range) => r,
+        validatePosition: (p: vscode.Position) => p,
+      } as vscode.TextDocument;
+    }
+
+    test("正常系 *から始まる行では completionLabelDefinition が呼ばれる", async () => {
+      const provider = new TyranoCompletionItemProvider();
+      const providerAny = provider as any;
+
+      // completionLabelDefinition を監視用の関数に差し替え
+      let called = false;
+      providerAny.completionLabelDefinition = async () => {
+        called = true;
+        return [];
+      };
+      providerAny.infoWs = {
+        getProjectPathByFilePath: async () => "/project",
+        labelMap: new Map(),
+        transitionMap: new Map(),
+      };
+      providerAny.parser = {
+        parseText: () => [],
+        getIndex: () => 0,
+      };
+
+      const document = makeMockDocumentWithLine("*my_label");
+      const position = new vscode.Position(0, 5);
+      const token = { isCancellationRequested: false, onCancellationRequested: new vscode.EventEmitter<any>().event };
+      const context = { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: undefined };
+
+      await provider.provideCompletionItems(
+        document,
+        position,
+        token,
+        context,
+      );
+
+      assert.ok(called, "completionLabelDefinitionが呼ばれるべき");
+    });
+
+    test("正常系 インデント付き（スペース）の*行でも completionLabelDefinition が呼ばれる", async () => {
+      const provider = new TyranoCompletionItemProvider();
+      const providerAny = provider as any;
+
+      let called = false;
+      providerAny.completionLabelDefinition = async () => {
+        called = true;
+        return [];
+      };
+      providerAny.infoWs = {
+        getProjectPathByFilePath: async () => "/project",
+        labelMap: new Map(),
+        transitionMap: new Map(),
+      };
+      providerAny.parser = {
+        parseText: () => [],
+        getIndex: () => 0,
+      };
+
+      const document = makeMockDocumentWithLine("  *indented_label");
+      const position = new vscode.Position(0, 5);
+      const token = { isCancellationRequested: false, onCancellationRequested: new vscode.EventEmitter<any>().event };
+      const context = { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: undefined };
+
+      await provider.provideCompletionItems(
+        document,
+        position,
+        token,
+        context,
+      );
+
+      assert.ok(called, "インデント付き*行でもcompletionLabelDefinitionが呼ばれるべき");
+    });
+
+    test("正常系 タブインデント付きの*行でも completionLabelDefinition が呼ばれる", async () => {
+      const provider = new TyranoCompletionItemProvider();
+      const providerAny = provider as any;
+
+      let called = false;
+      providerAny.completionLabelDefinition = async () => {
+        called = true;
+        return [];
+      };
+      providerAny.infoWs = {
+        getProjectPathByFilePath: async () => "/project",
+        labelMap: new Map(),
+        transitionMap: new Map(),
+      };
+      providerAny.parser = {
+        parseText: () => [],
+        getIndex: () => 0,
+      };
+
+      const document = makeMockDocumentWithLine("\t*tab_indented_label");
+      const position = new vscode.Position(0, 5);
+      const token = { isCancellationRequested: false, onCancellationRequested: new vscode.EventEmitter<any>().event };
+      const context = { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: undefined };
+
+      await provider.provideCompletionItems(
+        document,
+        position,
+        token,
+        context,
+      );
+
+      assert.ok(called, "タブインデント付き*行でもcompletionLabelDefinitionが呼ばれるべき");
+    });
+  });
 });

--- a/src/test/suite/subscriptions/TyranoCompletionItemProvider.test.ts
+++ b/src/test/suite/subscriptions/TyranoCompletionItemProvider.test.ts
@@ -606,6 +606,36 @@ suite("TyranoCompletionItemProvider", () => {
         "*を除いたラベル名が候補に表示されるべき",
       );
     });
+
+    test("正常系 変数参照（&を含むターゲット）は補完候補から除外される", async () => {
+      const provider = new TyranoCompletionItemProvider();
+      const providerAny = provider as any;
+
+      providerAny.infoWs = makeInfoWsMock({
+        definedLabels: [],
+        referencedTargets: [
+          "*&tf.selected_replay_obj",
+          "&tf.target_page",
+          "*&f.some_var",
+          "normal_label",
+        ],
+      });
+
+      const result = await providerAny.completionLabelDefinition(PROJECT_PATH);
+
+      assert.ok(Array.isArray(result), "配列が返されるべき");
+      assert.strictEqual(result.length, 1, "変数を除外して1件のみ返されるべき");
+      assert.strictEqual(
+        result[0].label,
+        "normal_label",
+        "通常のラベルのみ候補に含まれるべき",
+      );
+      const labels = result.map((item: any) => item.label);
+      assert.ok(
+        !labels.some((l: string) => l.includes("&")),
+        "変数参照（&を含む）は候補に含まれないべき",
+      );
+    });
   });
 
   // *から始まる行での provideCompletionItems ルーティングテスト


### PR DESCRIPTION
## 説明

`.ks` ファイルで `*` から始まる行（ラベル定義行）にカーソルを置いたとき、jump/call 系タグで参照されているが未定義のラベル名を補完候補として表示する機能を追加した。

- `TransitionData` に `targetLabel` ゲッターを追加し、private な `target` フィールドを外部から参照できるようにした
- `TyranoCompletionItemProvider` に `completionLabelDefinition` メソッドを追加
  - `labelMap` から定義済みラベル名セットを構築
  - `transitionMap` から参照されている target ラベル名を収集
  - 「参照あり & 未定義」のラベルのみを補完候補として返す
- `provideCompletionItems` に `/^[\t ]*\*/` による行頭検出を追加し、`*` 行では `completionLabelDefinition` を呼び出すようにした

## 関連するIssue

Closes #245

## テスト

- [x] `.ks` ファイルで `*` から始まる行で補完を起動し、jump ターゲットとして参照されているが未定義のラベルが候補に表示されることを確認
- [x] すでに定義済みのラベルは候補から除外されることを確認
- [x] インデント付き（スペース・タブ）の `*` 行でも補完が動作することを確認

## チェックリスト

- [x] コードレビューを依頼しましたか？
- [ ] ドキュメントを更新しましたか？
- [x] テストを実行し、すべてのテストが成功しましたか？

🤖 Generated with [Claude Code](https://claude.com/claude-code)