### PR TITLE
chore: Upgrade node versions for extension tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [18.x, 20.x]
+        node-version: [22.x, 24.x]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
# Upgrading node versions for CI extension tests 

<!-- プルリクエストのタイトルを記載してください。 -->

## 説明

<!-- 変更内容の詳細な説明を記載してください。 -->

The node versions 18 and 20 has been no more supported since 2025. So we need to upgrade the versions to 22 and 24. 

## テスト

<!-- 実施したテストの内容と結果を記載してください。 -->

Passed all specs in this project.

## チェックリスト

- [x] コードレビューを依頼しましたか？
- [ ] ドキュメントを更新しましたか？
- [ ] テストを実行し、すべてのテストが成功しましたか？
