### PR TITLE
issue245でstorage考慮処理を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "tyranosyntax" extension will be documented in this f
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.16.3] 2026-04-18
+
+- issue#245で発生した軽微なバグを修正しました。
+
 ## [1.16.2] 2026-04-17
 
 - 診断機能の軽微なバグを修正しました。[issue#341](https://github.com/orukRed/tyranosyntax/issues/341)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/orukRed/tyranosyntax"
   },
   "icon": "images/icon.png",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "engines": {
     "vscode": "^1.79.1"
   },

--- a/src/defineData/TransitionData.ts
+++ b/src/defineData/TransitionData.ts
@@ -26,6 +26,10 @@ export class TransitionData {
     return this.target;
   }
 
+  public get targetStorage(): string | undefined {
+    return this.storage;
+  }
+
   public constructor(
     tag: string,
     storage: string | undefined,

--- a/src/subscriptions/TyranoCompletionItemProvider.ts
+++ b/src/subscriptions/TyranoCompletionItemProvider.ts
@@ -154,7 +154,10 @@ export class TyranoCompletionItemProvider
 
       // *から始まる行（ラベル定義行）ならラベル補完を出す
       if (/^[\t ]*\*/.test(lineText)) {
-        return await this.completionLabelDefinition(projectPath);
+        return await this.completionLabelDefinition(
+          projectPath,
+          document.fileName,
+        );
       }
       //カーソルの左隣の文字取得
       if (
@@ -432,10 +435,14 @@ export class TyranoCompletionItemProvider
   /**
    * ラベル定義行（*から始まる行）でのインテリセンス。
    * プロジェクト内のjump系タグで参照されているが、まだ定義されていないラベル名を候補として返す。
+   * storageパラメータが指定されている場合、そのターゲットは指定先ファイルに属するため、
+   * 現在のファイルへの補完候補からは除外する。
    * @param projectPath
+   * @param currentDocumentPath 現在編集中のファイルの絶対パス
    */
   private async completionLabelDefinition(
     projectPath: string,
+    currentDocumentPath: string,
   ): Promise<
     | vscode.CompletionItem[]
     | vscode.CompletionList<vscode.CompletionItem>
@@ -453,6 +460,7 @@ export class TyranoCompletionItemProvider
     }
 
     // プロジェクト内のjump系タグで参照されているtargetラベル名を収集
+    // storageが指定されている場合はそのファイル、未指定の場合はtransitionが定義されたファイルに属する
     const referencedTargets = new Set<string>();
     for (const [filePath, transitions] of this.infoWs.transitionMap) {
       const transitionProjectPath =
@@ -467,7 +475,22 @@ export class TyranoCompletionItemProvider
               : target;
             // 変数参照（&を含む）はラベルではないため除外
             if (!normalized.includes("&")) {
-              referencedTargets.add(normalized);
+              // storageが指定されている場合、targetはそのstorage先ファイルに属する
+              // storageが未指定の場合、targetはtransitionが定義されたファイルに属する
+              const storage = transition.targetStorage;
+              const resolvedPath =
+                storage !== undefined
+                  ? projectPath +
+                    this.infoWs.DATA_DIRECTORY +
+                    this.infoWs.DATA_SCENARIO +
+                    this.infoWs.pathDelimiter +
+                    storage
+                  : filePath;
+              if (
+                this.infoWs.isSamePath(resolvedPath, currentDocumentPath)
+              ) {
+                referencedTargets.add(normalized);
+              }
             }
           }
         });

--- a/src/test/suite/subscriptions/TyranoCompletionItemProvider.test.ts
+++ b/src/test/suite/subscriptions/TyranoCompletionItemProvider.test.ts
@@ -508,6 +508,7 @@ suite("TyranoCompletionItemProvider", () => {
   // ラベル定義行（*から始まる行）の補完テスト
   suite("completionLabelDefinition", () => {
     const PROJECT_PATH = "/project";
+    const CURRENT_FILE = `${PROJECT_PATH}/data/scenario/first.ks`;
 
     /** infoWs のモックを組み立てるヘルパー */
     function makeInfoWsMock({
@@ -515,27 +516,34 @@ suite("TyranoCompletionItemProvider", () => {
       referencedTargets,
     }: {
       definedLabels: string[];
-      referencedTargets: string[];
+      referencedTargets: { targetLabel: string | undefined; targetStorage: string | undefined }[];
     }) {
       const labelMap = new Map<string, { name: string }[]>([
         [
-          `${PROJECT_PATH}/data/scenario/first.ks`,
+          CURRENT_FILE,
           definedLabels.map((name) => ({ name })),
         ],
       ]);
       const transitionMap = new Map<
         string,
-        { targetLabel: string | undefined }[]
+        { targetLabel: string | undefined; targetStorage: string | undefined }[]
       >([
         [
-          `${PROJECT_PATH}/data/scenario/first.ks`,
-          referencedTargets.map((t) => ({ targetLabel: t })),
+          CURRENT_FILE,
+          referencedTargets,
         ],
       ]);
       return {
         labelMap,
         transitionMap,
         getProjectPathByFilePath: async (_: string) => PROJECT_PATH,
+        isSamePath: (p1: string, p2: string) => {
+          const path = require("path");
+          return path.resolve(p1) === path.resolve(p2);
+        },
+        DATA_DIRECTORY: "/data",
+        DATA_SCENARIO: "/scenario",
+        pathDelimiter: "/",
       };
     }
 
@@ -545,10 +553,10 @@ suite("TyranoCompletionItemProvider", () => {
 
       providerAny.infoWs = makeInfoWsMock({
         definedLabels: [],
-        referencedTargets: ["undefined_label"],
+        referencedTargets: [{ targetLabel: "undefined_label", targetStorage: undefined }],
       });
 
-      const result = await providerAny.completionLabelDefinition(PROJECT_PATH);
+      const result = await providerAny.completionLabelDefinition(PROJECT_PATH, CURRENT_FILE);
 
       assert.ok(Array.isArray(result), "配列が返されるべき");
       assert.strictEqual(result.length, 1, "1件の候補が返されるべき");
@@ -570,10 +578,13 @@ suite("TyranoCompletionItemProvider", () => {
 
       providerAny.infoWs = makeInfoWsMock({
         definedLabels: ["already_defined"],
-        referencedTargets: ["already_defined", "undefined_label"],
+        referencedTargets: [
+          { targetLabel: "already_defined", targetStorage: undefined },
+          { targetLabel: "undefined_label", targetStorage: undefined },
+        ],
       });
 
-      const result = await providerAny.completionLabelDefinition(PROJECT_PATH);
+      const result = await providerAny.completionLabelDefinition(PROJECT_PATH, CURRENT_FILE);
 
       assert.ok(Array.isArray(result), "配列が返されるべき");
       const labels = result.map((item: any) => item.label);
@@ -593,10 +604,10 @@ suite("TyranoCompletionItemProvider", () => {
 
       providerAny.infoWs = makeInfoWsMock({
         definedLabels: [],
-        referencedTargets: ["*star_prefixed_label"],
+        referencedTargets: [{ targetLabel: "*star_prefixed_label", targetStorage: undefined }],
       });
 
-      const result = await providerAny.completionLabelDefinition(PROJECT_PATH);
+      const result = await providerAny.completionLabelDefinition(PROJECT_PATH, CURRENT_FILE);
 
       assert.ok(Array.isArray(result), "配列が返されるべき");
       assert.strictEqual(result.length, 1, "1件の候補が返されるべき");
@@ -614,14 +625,14 @@ suite("TyranoCompletionItemProvider", () => {
       providerAny.infoWs = makeInfoWsMock({
         definedLabels: [],
         referencedTargets: [
-          "*&tf.selected_replay_obj",
-          "&tf.target_page",
-          "*&f.some_var",
-          "normal_label",
+          { targetLabel: "*&tf.selected_replay_obj", targetStorage: undefined },
+          { targetLabel: "&tf.target_page", targetStorage: undefined },
+          { targetLabel: "*&f.some_var", targetStorage: undefined },
+          { targetLabel: "normal_label", targetStorage: undefined },
         ],
       });
 
-      const result = await providerAny.completionLabelDefinition(PROJECT_PATH);
+      const result = await providerAny.completionLabelDefinition(PROJECT_PATH, CURRENT_FILE);
 
       assert.ok(Array.isArray(result), "配列が返されるべき");
       assert.strictEqual(result.length, 1, "変数を除外して1件のみ返されるべき");
@@ -634,6 +645,60 @@ suite("TyranoCompletionItemProvider", () => {
       assert.ok(
         !labels.some((l: string) => l.includes("&")),
         "変数参照（&を含む）は候補に含まれないべき",
+      );
+    });
+
+    test("正常系 storage指定ありのtargetは現在のファイルの補完候補に含まれない", async () => {
+      const provider = new TyranoCompletionItemProvider();
+      const providerAny = provider as any;
+
+      providerAny.infoWs = makeInfoWsMock({
+        definedLabels: [],
+        referencedTargets: [
+          { targetLabel: "test1", targetStorage: undefined },
+          { targetLabel: "test2", targetStorage: "test.ks" },
+        ],
+      });
+
+      const result = await providerAny.completionLabelDefinition(PROJECT_PATH, CURRENT_FILE);
+
+      assert.ok(Array.isArray(result), "配列が返されるべき");
+      const labels = result.map((item: any) => item.label);
+      assert.ok(
+        labels.includes("test1"),
+        "storage未指定のtargetは現在のファイルの補完候補に含まれるべき",
+      );
+      assert.ok(
+        !labels.includes("test2"),
+        "storage指定ありのtargetは現在のファイルの補完候補に含まれないべき",
+      );
+    });
+
+    test("正常系 storage指定ありのtargetはstorage先ファイルの補完候補に含まれる", async () => {
+      const provider = new TyranoCompletionItemProvider();
+      const providerAny = provider as any;
+
+      const STORAGE_FILE = `${PROJECT_PATH}/data/scenario/test.ks`;
+
+      providerAny.infoWs = makeInfoWsMock({
+        definedLabels: [],
+        referencedTargets: [
+          { targetLabel: "test1", targetStorage: undefined },
+          { targetLabel: "test2", targetStorage: "test.ks" },
+        ],
+      });
+
+      const result = await providerAny.completionLabelDefinition(PROJECT_PATH, STORAGE_FILE);
+
+      assert.ok(Array.isArray(result), "配列が返されるべき");
+      const labels = result.map((item: any) => item.label);
+      assert.ok(
+        !labels.includes("test1"),
+        "storage未指定のtargetはstorage先ファイルの補完候補に含まれないべき",
+      );
+      assert.ok(
+        labels.includes("test2"),
+        "storage指定ありのtargetはstorage先ファイルの補完候補に含まれるべき",
       );
     });
   });

--- a/test_project/data/scenario/test/macro_test.ks
+++ b/test_project/data/scenario/test/macro_test.ks
@@ -26,3 +26,4 @@
 @issue300_test1 your_name=""
 @issue300_test2 color=""
 @issue300_test3
+

--- a/test_project/data/scenario/test/v1.16.2_test.ks
+++ b/test_project/data/scenario/test/v1.16.2_test.ks
@@ -1,0 +1,10 @@
+*start
+@jump storage="test/v1.16.2_test2.ks" target="*test2"
+@jump target="*test3"
+
+[s]
+
+*end
+bb
+
+*

--- a/test_project/data/scenario/test/v1.16.2_test2.ks
+++ b/test_project/data/scenario/test/v1.16.2_test2.ks
@@ -1,0 +1,9 @@
+*start
+@jump target="*test10"
+[s]
+
+*end
+bb
+
+
+*


### PR DESCRIPTION
storageが存在する場合の挙動がおかしかった（無関係のファイルで補完が表示されてしまう）ため修正しています。