### PR TITLE
ファイル/フォルダリネーム時に補完キャッシュが追従するよう修正

### DIFF
--- a/src/CrossFileContextManager.ts
+++ b/src/CrossFileContextManager.ts
@@ -4,6 +4,7 @@
  * ファイルをまたいだ変数補完を実現する。
  */
 import * as vscode from "vscode";
+import * as path from "path";
 
 // [iscript] は属性付き (例: [iscript cond="..."]) にも対応、大文字小文字不問
 const ISCRIPT_TAG_REGEX = /^\s*\[iscript(\s.*?)?\]\s*$/i;
@@ -17,6 +18,15 @@ const HAS_ISCRIPT_REGEX = /\[iscript[\s\]]|@iscript(?:\s|$)/i;
  */
 function hasScriptBlocksInText(text: string): boolean {
   return HAS_ISCRIPT_REGEX.test(text);
+}
+
+/**
+ * `**\/data/**\/*.ks` グロブと同じ判定を絶対パスに対して行う。
+ * Tyrano プロジェクトの data/ 配下にあるファイルかどうかを返す。
+ */
+function isUnderDataFolder(fsPath: string): boolean {
+  const normalized = fsPath.replace(/\\/g, "/");
+  return /\/data\//.test(normalized);
 }
 
 interface TextScriptBlock {
@@ -136,6 +146,50 @@ export class CrossFileContextManager implements vscode.Disposable {
     );
 
     this.disposables.push(this.watcher);
+
+    // VS Code の FileSystemWatcher はフォルダリネーム時に子ファイルの個別
+    // create/delete を発火しないため、リネーム反映は onDidRenameFiles で行う。
+    this.disposables.push(
+      vscode.workspace.onDidRenameFiles(async (event) => {
+        let changed = false;
+        for (const { oldUri, newUri } of event.files) {
+          let isDirectory = false;
+          try {
+            const stat = await vscode.workspace.fs.stat(newUri);
+            isDirectory = (stat.type & vscode.FileType.Directory) !== 0;
+          } catch {
+            continue;
+          }
+
+          if (isDirectory) {
+            const children = await vscode.workspace.findFiles(
+              new vscode.RelativePattern(newUri, "**/*.ks"),
+            );
+            for (const childNew of children) {
+              if (!isUnderDataFolder(childNew.fsPath)) continue;
+              const rel = path.relative(newUri.fsPath, childNew.fsPath);
+              const oldChildUri = vscode.Uri.file(
+                path.join(oldUri.fsPath, rel),
+              );
+              this.fileJsCache.delete(oldChildUri.toString());
+              await this.loadFile(childNew);
+              changed = true;
+            }
+          } else if (
+            path.extname(newUri.fsPath) === ".ks" &&
+            isUnderDataFolder(newUri.fsPath)
+          ) {
+            this.fileJsCache.delete(oldUri.toString());
+            await this.loadFile(newUri);
+            changed = true;
+          }
+        }
+        if (changed) {
+          this.otherContentCache.clear();
+          this.fireChangeDebounced();
+        }
+      }),
+    );
   }
 
   /**

--- a/src/InformationWorkSpace.ts
+++ b/src/InformationWorkSpace.ts
@@ -933,16 +933,32 @@ export class InformationWorkSpace {
   }
 
   /**
+   * 指定されたプロジェクトパス上の resourceFileMap から、対象ファイルパスのエントリを削除する。
+   * 旧パスがディスク上に存在しない（リネーム後の旧側）ケースで getProjectPathByFilePath が
+   * 失敗するのを避けるため、projectPath を呼び出し側から渡せるようにしたバリアント。
+   */
+  public spliceResourceFileMapByFilePathInProject(
+    projectPath: string,
+    filePath: string,
+  ) {
+    const insertValue: ResourceFileData[] | undefined = this.resourceFileMap
+      .get(projectPath)
+      ?.filter((obj) => obj.filePath !== filePath);
+    if (insertValue) {
+      this.resourceFileMap.set(projectPath, insertValue);
+    }
+  }
+
+  /**
    * 引数で指定したファイルパスを、リソースファイルのマップから削除
-   * @param absoluteProjectPath
    * @param filePath
    */
   public async spliceResourceFileMapByFilePath(filePath: string) {
     const absoluteProjectPath = await this.getProjectPathByFilePath(filePath);
-    const insertValue: ResourceFileData[] | undefined = this.resourceFileMap
-      .get(absoluteProjectPath)
-      ?.filter((obj) => obj.filePath !== filePath);
-    this.resourceFileMap.set(absoluteProjectPath, insertValue!);
+    this.spliceResourceFileMapByFilePathInProject(
+      absoluteProjectPath,
+      filePath,
+    );
   }
 
   /**
@@ -962,14 +978,16 @@ export class InformationWorkSpace {
   }
 
   /**
-   *  引数で指定したファイルパスを、マクロデータのマップから削除
-   * @param filePath
+   * spliceMacroDataMapByFilePath の projectPath を呼び出し側から渡せるバリアント。
+   * リネーム後の旧パスはディスク上に存在しないため、getProjectPathByFilePath では
+   * projectPath を解決できない。そうしたケースで使用する。
    */
-  public async spliceMacroDataMapByFilePath(filePath: string) {
+  public spliceMacroDataMapByFilePathInProject(
+    projectPath: string,
+    filePath: string,
+  ): string[] {
     const deleteTagList: string[] = [];
-    const projectPath = await this.getProjectPathByFilePath(filePath);
 
-    // 逆引きMapを使ってO(1)で該当マクロのUUIDを取得
     const macroUuids = this._macroByFilePath.get(filePath);
     if (!macroUuids || macroUuids.size === 0) {
       return deleteTagList;
@@ -981,7 +999,6 @@ export class InformationWorkSpace {
       return deleteTagList;
     }
 
-    // UUIDを使って直接削除
     for (const uuid of macroUuids) {
       const macroData = projectMacroMap.get(uuid);
       if (macroData) {
@@ -990,10 +1007,18 @@ export class InformationWorkSpace {
       }
     }
 
-    // 逆引きMapからも削除
     this._macroByFilePath.delete(filePath);
 
     return deleteTagList;
+  }
+
+  /**
+   *  引数で指定したファイルパスを、マクロデータのマップから削除
+   * @param filePath
+   */
+  public async spliceMacroDataMapByFilePath(filePath: string) {
+    const projectPath = await this.getProjectPathByFilePath(filePath);
+    return this.spliceMacroDataMapByFilePathInProject(projectPath, filePath);
   }
 
   /**
@@ -1005,11 +1030,12 @@ export class InformationWorkSpace {
   }
 
   /**
-   * 引数で指定したファイルパス（キー)の変数データマップを削除
-   * @param fsPath
+   * spliceVariableMapByFilePath の projectPath を呼び出し側から渡せるバリアント。
    */
-  public spliceVariableMapByFilePath(fsPath: string) {
-    const projectPath: string = this.getProjectPathByFilePathSync(fsPath);
+  public spliceVariableMapByFilePathInProject(
+    projectPath: string,
+    fsPath: string,
+  ) {
     const projectVariableMap = this.variableMap.get(projectPath);
     if (!projectVariableMap) return;
 
@@ -1024,6 +1050,15 @@ export class InformationWorkSpace {
   }
 
   /**
+   * 引数で指定したファイルパス（キー)の変数データマップを削除
+   * @param fsPath
+   */
+  public spliceVariableMapByFilePath(fsPath: string) {
+    const projectPath: string = this.getProjectPathByFilePathSync(fsPath);
+    this.spliceVariableMapByFilePathInProject(projectPath, fsPath);
+  }
+
+  /**
    * 引数で指定したファイルパス（キー）のトランジションデータマップを削除
    * @param fsPath
    */
@@ -1032,11 +1067,12 @@ export class InformationWorkSpace {
   }
 
   /**
-   *  引数で指定したファイルパス（Mapのキー）のCharacterDataをマップから削除
-   * @param fsPath
+   * spliceCharacterMapByFilePath の projectPath を呼び出し側から渡せるバリアント。
    */
-  public spliceCharacterMapByFilePath(fsPath: string) {
-    const projectPath: string = this.getProjectPathByFilePathSync(fsPath);
+  public spliceCharacterMapByFilePathInProject(
+    projectPath: string,
+    fsPath: string,
+  ) {
     const characterMap = this.characterMap.get(projectPath);
     if (!characterMap) return;
 
@@ -1056,6 +1092,15 @@ export class InformationWorkSpace {
     });
 
     this.characterMap.set(projectPath, updatedCharacterData);
+  }
+
+  /**
+   *  引数で指定したファイルパス（Mapのキー）のCharacterDataをマップから削除
+   * @param fsPath
+   */
+  public spliceCharacterMapByFilePath(fsPath: string) {
+    const projectPath: string = this.getProjectPathByFilePathSync(fsPath);
+    this.spliceCharacterMapByFilePathInProject(projectPath, fsPath);
   }
 
   /**
@@ -1322,15 +1367,25 @@ export class InformationWorkSpace {
   }
 
   /**
+   * splicePluginParamsByInitKsPath の projectPath を呼び出し側から渡せるバリアント。
+   */
+  public splicePluginParamsByInitKsPathInProject(
+    projectPath: string,
+    filePath: string,
+  ): void {
+    if (!projectPath) return;
+    const pluginName = this.extractPluginNameFromInitKs(filePath, projectPath);
+    if (!pluginName) return;
+    this._pluginParameterMap.get(projectPath)?.delete(pluginName);
+  }
+
+  /**
    * 指定した init.ks ファイルパスに対応するプラグインのパラメータ登録を削除する。
    * @param filePath
    */
   public async splicePluginParamsByInitKsPath(filePath: string): Promise<void> {
     const projectPath = await this.getProjectPathByFilePath(filePath);
-    if (!projectPath) return;
-    const pluginName = this.extractPluginNameFromInitKs(filePath, projectPath);
-    if (!pluginName) return;
-    this._pluginParameterMap.get(projectPath)?.delete(pluginName);
+    this.splicePluginParamsByInitKsPathInProject(projectPath, filePath);
   }
 
   public get scriptFileMap(): Map<string, string> {

--- a/src/InformationWorkSpace.ts
+++ b/src/InformationWorkSpace.ts
@@ -927,9 +927,10 @@ export class InformationWorkSpace {
         this.resourceExtensions[key].includes(path.extname(filePath)),
       )
       .toString(); //プロジェクトパスの拡張子からどのリソースタイプなのかを取得
-    this._resourceFileMap
-      .get(absoluteProjectPath)
-      ?.push(new ResourceFileData(filePath, resourceType));
+    const arr = this._resourceFileMap.get(absoluteProjectPath);
+    if (arr && !arr.some((r) => r.filePath === filePath)) {
+      arr.push(new ResourceFileData(filePath, resourceType));
+    }
   }
 
   /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -430,6 +430,19 @@ export function activate(context: ExtensionContext) {
               infoWs.spliceResourceFileMapByFilePath(e.fsPath);
             });
 
+            // VS Code の FileSystemWatcher はフォルダリネーム時に子ファイルの個別
+            // create/delete を発火しないため、リネームは onDidRenameFiles で捕捉する。
+            context.subscriptions.push(
+              vscode.workspace.onDidRenameFiles(async (event) => {
+                await new Promise((resolve) =>
+                  setTimeout(resolve, FILE_SYNC_DELAY_MS),
+                );
+                for (const { oldUri, newUri } of event.files) {
+                  await handleRenamedPath(infoWs, oldUri, newUri);
+                }
+              }),
+            );
+
             //すべてのプロジェクトに対して初回診断実行
             for (const i of infoWs.getTyranoScriptProjectRootPaths()) {
               tyranoDiagnostic.createDiagnostics(i + infoWs.pathDelimiter);
@@ -495,4 +508,114 @@ export function deactivate(): Thenable<void> | undefined {
     return undefined;
   }
   return client.stop();
+}
+
+/**
+ * Handle a single rename pair from `vscode.workspace.onDidRenameFiles`.
+ * Determines whether the new path is a directory; for directories, expands
+ * to all child files and reconstructs the corresponding old child paths so
+ * each splice/update pair targets the correct cache entry.
+ */
+async function handleRenamedPath(
+  infoWs: InformationWorkSpace,
+  oldUri: vscode.Uri,
+  newUri: vscode.Uri,
+): Promise<void> {
+  const newProjectPath = await infoWs.getProjectPathByFilePath(newUri.fsPath);
+  if (!newProjectPath) return;
+
+  // 旧パスはディスク上に存在しないため getProjectPathByFilePath は使えない。
+  // 既知のプロジェクトルートからプレフィックス一致で求める。
+  const oldProjectPath = resolveProjectPathByPrefix(infoWs, oldUri.fsPath);
+
+  let isDirectory = false;
+  try {
+    const stat = await vscode.workspace.fs.stat(newUri);
+    isDirectory = (stat.type & vscode.FileType.Directory) !== 0;
+  } catch {
+    return;
+  }
+
+  const effectiveOldProjectPath = oldProjectPath || newProjectPath;
+  if (isDirectory) {
+    const children = await vscode.workspace.findFiles(
+      new vscode.RelativePattern(newUri, "**/*"),
+    );
+    for (const child of children) {
+      const rel = path.relative(newUri.fsPath, child.fsPath);
+      const oldChildPath = oldUri.fsPath + infoWs.pathDelimiter + rel;
+      await handleRenamedFile(
+        infoWs,
+        oldChildPath,
+        child.fsPath,
+        effectiveOldProjectPath,
+      );
+    }
+  } else {
+    await handleRenamedFile(
+      infoWs,
+      oldUri.fsPath,
+      newUri.fsPath,
+      effectiveOldProjectPath,
+    );
+  }
+}
+
+/**
+ * For a single renamed file, splice the old path out of all relevant caches
+ * (using project-path-aware variants because the old path no longer exists
+ * on disk after the rename), then repopulate caches from the new path.
+ */
+async function handleRenamedFile(
+  infoWs: InformationWorkSpace,
+  oldPath: string,
+  newPath: string,
+  oldProjectPath: string,
+): Promise<void> {
+  const ext = path.extname(newPath);
+  if (ext === ".ks") {
+    await infoWs.spliceScenarioFileMapByFilePath(oldPath);
+    infoWs.spliceMacroDataMapByFilePathInProject(oldProjectPath, oldPath);
+    await infoWs.spliceLabelMapByFilePath(oldPath);
+    infoWs.spliceVariableMapByFilePathInProject(oldProjectPath, oldPath);
+    infoWs.spliceCharacterMapByFilePathInProject(oldProjectPath, oldPath);
+    await infoWs.spliceTransitionMapByFilePath(oldPath);
+    infoWs.splicePluginParamsByInitKsPathInProject(oldProjectPath, oldPath);
+
+    await infoWs.updateScenarioFileMap(newPath);
+    await infoWs.updateMacroLabelVariableDataMapByKs(newPath);
+    await infoWs.updatePluginParamsFromInitKs(newPath);
+  } else if (ext === ".js") {
+    await infoWs.spliceScriptFileMapByFilePath(oldPath);
+    infoWs.spliceMacroDataMapByFilePathInProject(oldProjectPath, oldPath);
+    infoWs.spliceVariableMapByFilePathInProject(oldProjectPath, oldPath);
+
+    await infoWs.updateScriptFileMap(newPath);
+    await infoWs.updateMacroDataMapByJs(newPath);
+  } else if (infoWs.resourceExtensionsArrays.includes(ext)) {
+    infoWs.spliceResourceFileMapByFilePathInProject(oldProjectPath, oldPath);
+    await infoWs.addResourceFileMap(newPath);
+  }
+}
+
+/**
+ * Resolve the Tyrano project root that contains the given (possibly
+ * non-existent) file path by prefix-matching against known project roots.
+ * Returns "" when no match — the caller is expected to fall back to the
+ * new path's project root.
+ */
+function resolveProjectPathByPrefix(
+  infoWs: InformationWorkSpace,
+  fsPath: string,
+): string {
+  const delimiter = infoWs.pathDelimiter;
+  for (const root of infoWs.getTyranoScriptProjectRootPaths()) {
+    if (
+      fsPath === root ||
+      fsPath.startsWith(root + delimiter)
+    ) {
+      return root;
+    }
+  }
+  return "";
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -538,16 +538,14 @@ async function handleRenamedPath(
 
   const effectiveOldProjectPath = oldProjectPath || newProjectPath;
   if (isDirectory) {
-    const children = await vscode.workspace.findFiles(
-      new vscode.RelativePattern(newUri, "**/*"),
-    );
-    for (const child of children) {
-      const rel = path.relative(newUri.fsPath, child.fsPath);
-      const oldChildPath = oldUri.fsPath + infoWs.pathDelimiter + rel;
+    const children = infoWs.getProjectFiles(newUri.fsPath, [], true);
+    for (const childFsPath of children) {
+      const rel = path.relative(newUri.fsPath, childFsPath);
+      const oldChildPath = path.join(oldUri.fsPath, rel);
       await handleRenamedFile(
         infoWs,
         oldChildPath,
-        child.fsPath,
+        childFsPath,
         effectiveOldProjectPath,
       );
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@
 
 import * as vscode from "vscode";
 import * as path from "path";
+import * as fs from "fs";
 import { ExtensionContext } from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 
@@ -530,8 +531,7 @@ async function handleRenamedPath(
 
   let isDirectory = false;
   try {
-    const stat = await vscode.workspace.fs.stat(newUri);
-    isDirectory = (stat.type & vscode.FileType.Directory) !== 0;
+    isDirectory = fs.statSync(newUri.fsPath).isDirectory();
   } catch {
     return;
   }
@@ -579,17 +579,21 @@ async function handleRenamedFile(
     infoWs.spliceCharacterMapByFilePathInProject(oldProjectPath, oldPath);
     await infoWs.spliceTransitionMapByFilePath(oldPath);
     infoWs.splicePluginParamsByInitKsPathInProject(oldProjectPath, oldPath);
+    infoWs.spliceResourceFileMapByFilePathInProject(oldProjectPath, oldPath);
 
     await infoWs.updateScenarioFileMap(newPath);
     await infoWs.updateMacroLabelVariableDataMapByKs(newPath);
     await infoWs.updatePluginParamsFromInitKs(newPath);
+    await infoWs.addResourceFileMap(newPath);
   } else if (ext === ".js") {
     await infoWs.spliceScriptFileMapByFilePath(oldPath);
     infoWs.spliceMacroDataMapByFilePathInProject(oldProjectPath, oldPath);
     infoWs.spliceVariableMapByFilePathInProject(oldProjectPath, oldPath);
+    infoWs.spliceResourceFileMapByFilePathInProject(oldProjectPath, oldPath);
 
     await infoWs.updateScriptFileMap(newPath);
     await infoWs.updateMacroDataMapByJs(newPath);
+    await infoWs.addResourceFileMap(newPath);
   } else if (infoWs.resourceExtensionsArrays.includes(ext)) {
     infoWs.spliceResourceFileMapByFilePathInProject(oldProjectPath, oldPath);
     await infoWs.addResourceFileMap(newPath);


### PR DESCRIPTION
VS Code の FileSystemWatcher はフォルダリネーム時に子ファイルの個別
create/delete を発火しないため、補完用の resourceFileMap や scenarioFileMap
が古いパスのまま残ってしまっていた。`onDidRenameFiles` を購読して、
旧パスをキャッシュから splice しつつ新パスから再構築するようにした。

リネーム後の旧パスはディスク上に存在しないため、`getProjectPathByFilePath`
が "" を返してしまい既存の splice ヘルパが silently no-op になる問題があ
ったので、`projectPath` を呼び出し側から渡せる *InProject バリアントを
splice 群に追加し、既存版はそちらに委譲する形にした。

Fixes #176

https://claude.ai/code/session_01B1CDvKWz8kMfXvKgmo8WZT