### PR TITLE
ワークスペースフォルダ・設定変更・埋め込みJSキャッシュの更新漏れを修正

### DIFF
--- a/src/CrossFileContextManager.ts
+++ b/src/CrossFileContextManager.ts
@@ -4,6 +4,7 @@
  * ファイルをまたいだ変数補完を実現する。
  */
 import * as vscode from "vscode";
+import * as path from "path";
 
 // [iscript] は属性付き (例: [iscript cond="..."]) にも対応、大文字小文字不問
 const ISCRIPT_TAG_REGEX = /^\s*\[iscript(\s.*?)?\]\s*$/i;
@@ -161,6 +162,44 @@ export class CrossFileContextManager implements vscode.Disposable {
       // ファイル読み込みエラー（削除済み等）は無視
       this.fileJsCache.delete(uri.toString());
       this.otherContentCache.clear();
+    }
+  }
+
+  /**
+   * 新しく追加されたワークスペースフォルダ配下の data/.ks をスキャンしてキャッシュに取り込む。
+   * 既存の FileSystemWatcher は workspace 全体に適用されるため、新規ファイル追加自体は
+   * 自動で拾えるが、既存ファイルの初回スキャンはこのメソッドで明示的に行う必要がある。
+   */
+  async addFolder(folderUri: vscode.Uri): Promise<void> {
+    const files = await vscode.workspace.findFiles(
+      new vscode.RelativePattern(folderUri, "**/data/**/*.ks"),
+    );
+    await Promise.all(files.map((uri) => this.loadFile(uri)));
+    this.fireChangeDebounced();
+  }
+
+  /**
+   * 取り除かれたワークスペースフォルダ配下のキャッシュエントリを削除する。
+   */
+  removeFolder(folderUri: vscode.Uri): void {
+    const folderPath = folderUri.fsPath;
+    let changed = false;
+    for (const key of [...this.fileJsCache.keys()]) {
+      let cachedPath: string;
+      try {
+        cachedPath = vscode.Uri.parse(key).fsPath;
+      } catch {
+        continue;
+      }
+      const rel = path.relative(folderPath, cachedPath);
+      if (!rel.startsWith("..") && !path.isAbsolute(rel)) {
+        this.fileJsCache.delete(key);
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.otherContentCache.clear();
+      this.fireChangeDebounced();
     }
   }
 

--- a/src/InformationWorkSpace.ts
+++ b/src/InformationWorkSpace.ts
@@ -72,14 +72,29 @@ export class InformationWorkSpace {
   >(); //ファイル名、TransitionDataの配列
   private defaultTagList: string[] = [];
 
-  private readonly _resourceExtensions: object = vscode.workspace
+  private _resourceExtensions: object = vscode.workspace
     .getConfiguration()
     .get("TyranoScript syntax.resource.extension")!;
-  private readonly _resourceExtensionsArrays = Object.keys(
+  private _resourceExtensionsArrays: string[] = Object.keys(
     this.resourceExtensions,
   )
     .map((key) => this.resourceExtensions[key])
     .flat(); //resourceExtensionsをオブジェクトからstring型の一次配列にする
+
+  /**
+   * `TyranoScript syntax.resource.extension` 設定を読み直して
+   * `_resourceExtensions` / `_resourceExtensionsArrays` を再構築する。
+   * 設定変更時に呼び出す。
+   */
+  public reloadResourceExtensions(): void {
+    this._resourceExtensions =
+      vscode.workspace
+        .getConfiguration()
+        .get("TyranoScript syntax.resource.extension") ?? {};
+    this._resourceExtensionsArrays = Object.keys(this._resourceExtensions)
+      .map((key) => this._resourceExtensions[key])
+      .flat();
+  }
   private readonly pluginTags: object = JSON.parse(
     JSON.stringify(
       vscode.workspace
@@ -129,95 +144,130 @@ export class InformationWorkSpace {
       TyranoLogger.print(`Opening workspace is ${value.uri.fsPath}`);
     });
 
-    //最初のキーをプロジェクト名で初期化
+    this._macroByFilePath.clear();
     for (const projectPath of this.getTyranoScriptProjectRootPaths()) {
-      TyranoLogger.print(`${projectPath} variable initialzie start`);
-      this.defineMacroMap.set(projectPath, new Map<string, DefineMacroData>());
-      this._macroByFilePath.clear(); // 逆引きMapも初期化
-      this._resourceFileMap.set(projectPath, []);
-      this.variableMap.set(projectPath, new Map<string, VariableData>());
-      try {
-        const passJoined = this.getSnippetPath();
-        const jsonData = fs.readFileSync(passJoined, "utf8");
-        const parsedJson = JSON.parse(jsonData);
-        const combinedObject = { ...parsedJson, ...this.pluginTags };
-
-        this.defaultTagList = Object.keys(parsedJson);
-        this.defaultTagList.push(...Object.keys(this.pluginTags)); //pluginTagsをdefaultTagListに追加
-        this.suggestions.set(projectPath, combinedObject);
-        if (Object.keys(this.suggestions.get(projectPath)!).length === 0) {
-          throw new Error("suggestions is empty");
-        }
-      } catch (error) {
-        TyranoLogger.print(
-          "passJoin or JSON.parse or readFile Sync failed",
-          ErrorLevel.ERROR,
-        );
-        TyranoLogger.printStackTrace(error);
-      }
-      this.characterMap.set(projectPath, []);
-      this._pluginParameterMap.set(
-        projectPath,
-        new Map<string, Set<string>>(),
-      );
-      TyranoLogger.print(`${projectPath} variable initialzie end`);
+      await this.addProject(projectPath);
     }
+  }
 
-    for (const projectPath of this.getTyranoScriptProjectRootPaths()) {
-      TyranoLogger.print(`${projectPath} is loading...`);
-      //スクリプトファイルパスを初期化
-      TyranoLogger.print(`${projectPath}'s scripts is loading...`);
-      const absoluteScriptFilePaths = this.getProjectFiles(
-        projectPath + this.DATA_DIRECTORY,
-        [".js"],
-        true,
-      ); //dataディレクトリ内の.jsファイルを取得
-      // 並列処理で高速化
-      await Promise.all(
-        absoluteScriptFilePaths.map(async (i) => {
-          await this.updateScriptFileMap(i);
-          await this.updateMacroDataMapByJs(i);
-        }),
+  /**
+   * 単一プロジェクトのキャッシュを初期化し、data/配下のファイルをロードする。
+   * すでに初期化済み（resourceFileMapにキーが存在）であれば何もしない。
+   * ワークスペースフォルダ追加時のキャッチアップに用いる。
+   */
+  public async addProject(projectPath: string): Promise<void> {
+    if (this._resourceFileMap.has(projectPath)) {
+      return;
+    }
+    TyranoLogger.print(`${projectPath} variable initialzie start`);
+    this.defineMacroMap.set(projectPath, new Map<string, DefineMacroData>());
+    this._resourceFileMap.set(projectPath, []);
+    this.variableMap.set(projectPath, new Map<string, VariableData>());
+    try {
+      const passJoined = this.getSnippetPath();
+      const jsonData = fs.readFileSync(passJoined, "utf8");
+      const parsedJson = JSON.parse(jsonData);
+      const combinedObject = { ...parsedJson, ...this.pluginTags };
+
+      this.defaultTagList = Object.keys(parsedJson);
+      this.defaultTagList.push(...Object.keys(this.pluginTags));
+      this.suggestions.set(projectPath, combinedObject);
+      if (Object.keys(this.suggestions.get(projectPath)!).length === 0) {
+        throw new Error("suggestions is empty");
+      }
+    } catch (error) {
+      TyranoLogger.print(
+        "passJoin or JSON.parse or readFile Sync failed",
+        ErrorLevel.ERROR,
       );
-      //シナリオファイルを初期化
-      TyranoLogger.print(`${projectPath}'s scenarios is loading...`);
-      const absoluteScenarioFilePaths = await this.getProjectFiles(
-        projectPath + this.DATA_DIRECTORY,
-        [".ks"],
-        true,
-      ); //dataディレクトリ内の.ksファイルを取得
-      // 並列処理で高速化
-      await Promise.all(
-        absoluteScenarioFilePaths.map(async (i) => {
-          await this.updateScenarioFileMap(i);
-          await this.updateMacroLabelVariableDataMapByKs(i);
-        }),
-      );
-      // プラグインフォルダの init.ks から mp.* を抽出
-      TyranoLogger.print(`${projectPath}'s plugin init.ks is loading...`);
-      const pluginInitKsPaths = absoluteScenarioFilePaths.filter(
-        (p) =>
-          this.isPluginFile(p, projectPath) &&
-          path.basename(p) === "init.ks",
-      );
-      await Promise.all(
-        pluginInitKsPaths.map(async (p) => {
-          await this.updatePluginParamsFromInitKs(p);
-        }),
-      );
-      //リソースファイルを取得
-      TyranoLogger.print(`${projectPath}'s resource file is loading...`);
-      const absoluteResourceFilePaths = this.getProjectFiles(
-        projectPath + this.DATA_DIRECTORY,
-        this.resourceExtensionsArrays,
-        true,
-      ); //dataディレクトリのファイル取得
-      // 並列処理で高速化
-      await Promise.all(
-        absoluteResourceFilePaths.map(async (i) => {
-          await this.addResourceFileMap(i);
-        }),
-      );
+      TyranoLogger.printStackTrace(error);
+    }
+    this.characterMap.set(projectPath, []);
+    this._pluginParameterMap.set(projectPath, new Map<string, Set<string>>());
+    TyranoLogger.print(`${projectPath} variable initialzie end`);
+
+    TyranoLogger.print(`${projectPath} is loading...`);
+    TyranoLogger.print(`${projectPath}'s scripts is loading...`);
+    const absoluteScriptFilePaths = this.getProjectFiles(
+      projectPath + this.DATA_DIRECTORY,
+      [".js"],
+      true,
+    );
+    await Promise.all(
+      absoluteScriptFilePaths.map(async (i) => {
+        await this.updateScriptFileMap(i);
+        await this.updateMacroDataMapByJs(i);
+      }),
+    );
+    TyranoLogger.print(`${projectPath}'s scenarios is loading...`);
+    const absoluteScenarioFilePaths = await this.getProjectFiles(
+      projectPath + this.DATA_DIRECTORY,
+      [".ks"],
+      true,
+    );
+    await Promise.all(
+      absoluteScenarioFilePaths.map(async (i) => {
+        await this.updateScenarioFileMap(i);
+        await this.updateMacroLabelVariableDataMapByKs(i);
+      }),
+    );
+    TyranoLogger.print(`${projectPath}'s plugin init.ks is loading...`);
+    const pluginInitKsPaths = absoluteScenarioFilePaths.filter(
+      (p) =>
+        this.isPluginFile(p, projectPath) && path.basename(p) === "init.ks",
+    );
+    await Promise.all(
+      pluginInitKsPaths.map(async (p) => {
+        await this.updatePluginParamsFromInitKs(p);
+      }),
+    );
+    TyranoLogger.print(`${projectPath}'s resource file is loading...`);
+    const absoluteResourceFilePaths = this.getProjectFiles(
+      projectPath + this.DATA_DIRECTORY,
+      this.resourceExtensionsArrays,
+      true,
+    );
+    await Promise.all(
+      absoluteResourceFilePaths.map(
+        async (i) => await this.addResourceFileMap(i),
+      ),
+    );
+    TyranoLogger.print(`${projectPath} is loaded.`);
+  }
+
+  /**
+   * プロジェクトに紐づくキャッシュを全て削除する。
+   * ワークスペースフォルダから外されたプロジェクトのクリーンアップに用いる。
+   */
+  public removeProject(projectPath: string): void {
+    if (!projectPath) return;
+    TyranoLogger.print(`removeProject: ${projectPath}`);
+
+    this.defineMacroMap.delete(projectPath);
+    this._resourceFileMap.delete(projectPath);
+    this.variableMap.delete(projectPath);
+    this.characterMap.delete(projectPath);
+    this._pluginParameterMap.delete(projectPath);
+    this.suggestions.delete(projectPath);
+
+    const projectPrefix = projectPath + this.pathDelimiter;
+    const isUnderProject = (key: string) =>
+      key === projectPath || key.startsWith(projectPrefix);
+
+    for (const key of [...this._scenarioFileMap.keys()]) {
+      if (isUnderProject(key)) this._scenarioFileMap.delete(key);
+    }
+    for (const key of [...this._scriptFileMap.keys()]) {
+      if (isUnderProject(key)) this._scriptFileMap.delete(key);
+    }
+    for (const key of [...this._labelMap.keys()]) {
+      if (isUnderProject(key)) this._labelMap.delete(key);
+    }
+    for (const key of [...this._transitionMap.keys()]) {
+      if (isUnderProject(key)) this._transitionMap.delete(key);
+    }
+    for (const key of [...this._macroByFilePath.keys()]) {
+      if (isUnderProject(key)) this._macroByFilePath.delete(key);
     }
   }
 

--- a/src/embeddedJavaScriptSupport.ts
+++ b/src/embeddedJavaScriptSupport.ts
@@ -717,7 +717,87 @@ export function registerEmbeddedJavaScriptSupport(
     }),
   );
 
+  // --- ファイル/フォルダリネームへの追従 ---
+  // 各キャッシュは旧URI文字列をキーにしているため、リネームで新しいパスに
+  // 切り替わった後も旧キーが残り続ける（メモリリークと診断UIの古い表示の原因）。
+  // ここで明示的に旧キーを掃除する。
+  context.subscriptions.push(
+    vscode.workspace.onDidRenameFiles(async (event) => {
+      for (const { oldUri, newUri } of event.files) {
+        let isDirectory = false;
+        try {
+          const stat = await vscode.workspace.fs.stat(newUri);
+          isDirectory = (stat.type & vscode.FileType.Directory) !== 0;
+        } catch {
+          continue;
+        }
+        cleanupCachesForRenamedPath(oldUri, isDirectory, diagnosticCollection);
+      }
+    }),
+  );
+
+  // --- ワークスペースフォルダ追加/削除への追従 ---
+  // crossFileContext は activate 時に1回しか init() しないため、
+  // 後から追加されたフォルダの .ks がキャッシュに乗らない。明示的にスキャンする。
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeWorkspaceFolders(async (event) => {
+      for (const removed of event.removed) {
+        crossFileContext.removeFolder(removed.uri);
+      }
+      for (const added of event.added) {
+        await crossFileContext.addFolder(added.uri);
+      }
+    }),
+  );
+
   console.log("[iscript] Embedded JavaScript Support registered");
+}
+
+/**
+ * リネーム対象のドキュメント/フォルダに紐づく全てのキャッシュエントリを削除する。
+ * documentCacheMap / debounceTimers は元ドキュメント URI をキー、
+ * virtualContentMap / virtualToOriginalMap / openedVirtualDocs は仮想 URI をキーとする。
+ * 仮想 URI 側は virtualToOriginalMap を逆引きして対応するエントリを掃除する。
+ */
+function cleanupCachesForRenamedPath(
+  oldUri: vscode.Uri,
+  isDirectory: boolean,
+  diagnosticCollection: vscode.DiagnosticCollection,
+): void {
+  const oldUriStr = oldUri.toString();
+  const oldUriPrefix = isDirectory ? oldUriStr + "/" : null;
+
+  const matches = (key: string) =>
+    key === oldUriStr || (oldUriPrefix !== null && key.startsWith(oldUriPrefix));
+
+  for (const key of [...documentCacheMap.keys()]) {
+    if (matches(key)) {
+      documentCacheMap.delete(key);
+    }
+  }
+
+  for (const key of [...debounceTimers.keys()]) {
+    if (matches(key)) {
+      const timer = debounceTimers.get(key);
+      if (timer) clearTimeout(timer);
+      debounceTimers.delete(key);
+    }
+  }
+
+  for (const [virtualKey, originalUriStr] of [
+    ...virtualToOriginalMap.entries(),
+  ]) {
+    if (matches(originalUriStr)) {
+      virtualContentMap.delete(virtualKey);
+      virtualToOriginalMap.delete(virtualKey);
+      openedVirtualDocs.delete(virtualKey);
+      try {
+        diagnosticCollection.delete(vscode.Uri.parse(originalUriStr));
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -415,20 +415,112 @@ export function activate(context: ExtensionContext) {
               await infoWs.spliceVariableMapByFilePath(e.fsPath);
             });
 
-            const resourceGlob = `**/*{${infoWs.resourceExtensionsArrays.toString()}}`; //TyranoScript syntax.resource.extensionで指定したすべての拡張子を取得
-            const resourceFileSystemWatcher: vscode.FileSystemWatcher =
-              vscode.workspace.createFileSystemWatcher(
+            // リソースファイルウォッチャー。`resource.extension` 設定変更時に
+            // 再生成できるようローカル変数に保持する。
+            let resourceWatcherBundle: vscode.Disposable[] = [];
+            const createResourceWatcher = () => {
+              for (const d of resourceWatcherBundle) d.dispose();
+              const resourceGlob = `**/*{${infoWs.resourceExtensionsArrays.toString()}}`;
+              const watcher = vscode.workspace.createFileSystemWatcher(
                 resourceGlob,
                 false,
                 false,
                 false,
               );
-            resourceFileSystemWatcher.onDidCreate(async (e) => {
-              infoWs.addResourceFileMap(e.fsPath);
+              const onCreate = watcher.onDidCreate(async (e) => {
+                infoWs.addResourceFileMap(e.fsPath);
+              });
+              const onDelete = watcher.onDidDelete(async (e) => {
+                infoWs.spliceResourceFileMapByFilePath(e.fsPath);
+              });
+              resourceWatcherBundle = [watcher, onCreate, onDelete];
+            };
+            createResourceWatcher();
+            context.subscriptions.push({
+              dispose: () => {
+                for (const d of resourceWatcherBundle) d.dispose();
+              },
             });
-            resourceFileSystemWatcher.onDidDelete(async (e) => {
-              infoWs.spliceResourceFileMapByFilePath(e.fsPath);
-            });
+
+            // ワークスペースフォルダ追加/削除に追従。
+            // フォルダ追加時は新しい Tyrano プロジェクトをスキャンしてキャッシュを構築。
+            // フォルダ削除時は対象プロジェクト配下のキャッシュをクリーンアップ。
+            context.subscriptions.push(
+              vscode.workspace.onDidChangeWorkspaceFolders(async () => {
+                const currentProjects = new Set(
+                  infoWs.getTyranoScriptProjectRootPaths(),
+                );
+                const knownProjects = new Set(infoWs.resourceFileMap.keys());
+
+                for (const projectPath of knownProjects) {
+                  if (!currentProjects.has(projectPath)) {
+                    infoWs.removeProject(projectPath);
+                  }
+                }
+                for (const projectPath of currentProjects) {
+                  if (!knownProjects.has(projectPath)) {
+                    await infoWs.addProject(projectPath);
+                    tyranoDiagnostic.createDiagnostics(
+                      projectPath + infoWs.pathDelimiter,
+                    );
+                  }
+                }
+              }),
+            );
+
+            // 設定変更への追従。
+            // `resource.extension` はウォッチャーのglob・補完候補に直結するので
+            // ライブで再構築する。それ以外の挙動系設定はリロード推奨に留める。
+            context.subscriptions.push(
+              vscode.workspace.onDidChangeConfiguration(async (event) => {
+                if (
+                  event.affectsConfiguration(
+                    "TyranoScript syntax.resource.extension",
+                  )
+                ) {
+                  infoWs.reloadResourceExtensions();
+                  createResourceWatcher();
+                  // 既存プロジェクトのリソースキャッシュを新拡張子で再構築
+                  for (const projectPath of infoWs.getTyranoScriptProjectRootPaths()) {
+                    infoWs.resourceFileMap.set(projectPath, []);
+                    const resources = infoWs.getProjectFiles(
+                      projectPath + infoWs.DATA_DIRECTORY,
+                      infoWs.resourceExtensionsArrays,
+                      true,
+                    );
+                    await Promise.all(
+                      resources.map((p) => infoWs.addResourceFileMap(p)),
+                    );
+                  }
+                }
+
+                if (
+                  event.affectsConfiguration(
+                    "TyranoScript syntax.plugin.parameter",
+                  ) ||
+                  event.affectsConfiguration(
+                    "TyranoScript syntax.parser.read_plugin",
+                  ) ||
+                  event.affectsConfiguration(
+                    "TyranoScript syntax.parser.autoLoadPluginTags",
+                  )
+                ) {
+                  const reloadLabel = "再読み込み";
+                  vscode.window
+                    .showInformationMessage(
+                      "TyranoScript syntax: 設定を反映するにはウィンドウを再読み込みしてください。",
+                      reloadLabel,
+                    )
+                    .then((choice) => {
+                      if (choice === reloadLabel) {
+                        vscode.commands.executeCommand(
+                          "workbench.action.reloadWindow",
+                        );
+                      }
+                    });
+                }
+              }),
+            );
 
             //すべてのプロジェクトに対して初回診断実行
             for (const i of infoWs.getTyranoScriptProjectRootPaths()) {


### PR DESCRIPTION
## 概要

#176 の調査の過程で、リネーム以外にも複数のキャッシュ更新漏れが見つかったため別PRで対応します。

### 修正内容

#### 1. ワークスペースフォルダ追加/削除に未対応（HIGH）
- `vscode.workspace.onDidChangeWorkspaceFolders` がどこにも購読されておらず、後から追加したプロジェクトが補完候補に出ない／削除したプロジェクトのエントリが残り続けていた。
- `InformationWorkSpace` に `addProject(projectPath)` / `removeProject(projectPath)` を切り出し、`onDidChangeWorkspaceFolders` から呼び出すようにした。`initializeMaps` もこれらに委譲する形にリファクタ。
- `CrossFileContextManager` も同様の問題があったので `addFolder(folderUri)` / `removeFolder(folderUri)` を追加し、`embeddedJavaScriptSupport` 側で同イベントから呼ぶようにした。

#### 2. `resource.extension` 設定変更が反映されない（MEDIUM）
- リソースファイルウォッチャーの glob と `_resourceExtensionsArrays` が `InformationWorkSpace` のコンストラクタで1度だけ構築されていたため、`TyranoScript syntax.resource.extension` を変更してもウィンドウ再起動まで新しい拡張子が認識されなかった。
- `reloadResourceExtensions()` メソッドを追加し、`onDidChangeConfiguration` でウォッチャーを再生成 + 既存プロジェクトのリソースキャッシュを再構築。
- プラグイン/パーサ系設定 (`plugin.parameter` / `parser.read_plugin` / `parser.autoLoadPluginTags`) はリロード推奨の通知に留めた。

#### 3. 埋め込みJSサポートのキャッシュリネーム未対応（HIGH/MEDIUM）
- `documentCacheMap` / `virtualContentMap` / `virtualToOriginalMap` / `openedVirtualDocs` / `debounceTimers` / `diagnosticCollection` がファイル・フォルダリネーム時に旧URIキーを掃除していなかった（メモリリーク + 古い診断UIが残る）。
- `onDidRenameFiles` を購読し、`virtualToOriginalMap` を逆引きして関連エントリをまとめて掃除する `cleanupCachesForRenamedPath` ヘルパを追加。

### 関連 Issue

- #176 でのリネーム調査の派生。本PR自体は #176 の修正には依存しない（並行マージ可）。

### 修正ファイル

- `src/InformationWorkSpace.ts` — `addProject` / `removeProject` / `reloadResourceExtensions` を追加。`initializeMaps` を簡素化。
- `src/extension.ts` — `onDidChangeWorkspaceFolders` / `onDidChangeConfiguration` ハンドラを追加。リソースウォッチャーを再生成可能に。
- `src/embeddedJavaScriptSupport.ts` — `onDidRenameFiles` / `onDidChangeWorkspaceFolders` ハンドラを追加。
- `src/CrossFileContextManager.ts` — `addFolder` / `removeFolder` メソッドを追加。

### Test plan

- [ ] `npm run compile` 成功（ローカル確認済み）
- [ ] `npm run lint` 既存と同水準（新規 error 0 件、warning は cognitive-complexity 16 が2箇所だがプロジェクト既存の警告は最大97なので相対的に問題なし）
- [ ] 手動: VS Code でフォルダなしで起動 → Tyrano プロジェクトを後から追加 → 補完候補が出ること
- [ ] 手動: 複数プロジェクト開いた状態で1つフォルダから外す → 残ったプロジェクトの補完が継続して動くこと
- [ ] 手動: `TyranoScript syntax.resource.extension` に `.webp` を追加 → 再起動なしで `.webp` ファイルが補完候補に出ること
- [ ] 手動: `.ks` ファイルを大量にリネームしてもメモリ使用量が増え続けないこと（埋め込みJSキャッシュの掃除確認）

https://claude.ai/code/session_01B1CDvKWz8kMfXvKgmo8WZT

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1CDvKWz8kMfXvKgmo8WZT)_