### PR TITLE
Add HTML block comment support to toggle comment feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "tyranosyntax" extension will be documented in this f
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Unreleased]
+
+- `Ctrl+/`（Mac: `Cmd+/`）によるコメントトグルが`[html]`〜`[endhtml]`ブロック内でも対応しました。ブロック内では`<!-- -->`（HTMLコメント）でコメントアウト／解除されます。
+
 ## [3.2.0] 2026-05-28
 
 - .ksファイルのコードフォーマット機能を追加しました。VS Code標準の「ドキュメントのフォーマット」（`Shift+Alt+F`）で以下の整形が行われます。

--- a/src/subscriptions/TyranoToggleComment.ts
+++ b/src/subscriptions/TyranoToggleComment.ts
@@ -3,6 +3,37 @@ import * as vscode from "vscode";
 const ISCRIPT_START = /^(\[\s*iscript\b|@iscript\b)/i;
 const ISCRIPT_END = /^(\[\s*endscript\b|@endscript\b)/i;
 
+const HTML_START = /^(\[\s*html\b|@html\b)/i;
+const HTML_END = /^(\[\s*endhtml\b|@endhtml\b)/i;
+
+/**
+ * 指定行が start〜end のタグで囲まれたブロックの内側かどうかを判定する。
+ * 開始 / 終了タグ行そのものはブロックの外側として扱う。
+ */
+function isInsideBlock(
+  document: vscode.TextDocument,
+  lineNo: number,
+  startTag: RegExp,
+  endTag: RegExp,
+): boolean {
+  const current = document.lineAt(lineNo).text.trim();
+  if (startTag.test(current) || endTag.test(current)) {
+    return false;
+  }
+  let inside = false;
+  for (let i = 0; i < lineNo; i++) {
+    const trimmed = document.lineAt(i).text.trim();
+    if (!inside) {
+      if (startTag.test(trimmed)) {
+        inside = true;
+      }
+    } else if (endTag.test(trimmed)) {
+      inside = false;
+    }
+  }
+  return inside;
+}
+
 /**
  * 指定行が [iscript]〜[endscript] ブロックの内側かどうかを判定する。
  * iscript / endscript のタグ行そのものは tyrano 行（外側）として扱う。
@@ -11,44 +42,52 @@ export function isInsideIscript(
   document: vscode.TextDocument,
   lineNo: number,
 ): boolean {
-  const current = document.lineAt(lineNo).text.trim();
-  if (ISCRIPT_START.test(current) || ISCRIPT_END.test(current)) {
-    return false;
-  }
-  let inside = false;
-  for (let i = 0; i < lineNo; i++) {
-    const trimmed = document.lineAt(i).text.trim();
-    if (!inside) {
-      if (ISCRIPT_START.test(trimmed)) {
-        inside = true;
-      }
-    } else if (ISCRIPT_END.test(trimmed)) {
-      inside = false;
-    }
-  }
-  return inside;
+  return isInsideBlock(document, lineNo, ISCRIPT_START, ISCRIPT_END);
 }
 
-// tyrano 言語の lineComment を一時的に上書きするための Disposable。
+/**
+ * 指定行が [html]〜[endhtml] ブロックの内側かどうかを判定する。
+ * html / endhtml のタグ行そのものは tyrano 行（外側）として扱う。
+ */
+export function isInsideHtml(
+  document: vscode.TextDocument,
+  lineNo: number,
+): boolean {
+  return isInsideBlock(document, lineNo, HTML_START, HTML_END);
+}
+
+// tyrano 言語の comments 設定を一時的に上書きするための Disposable。
 let commentConfig: vscode.Disposable | undefined;
 
-function setLineComment(token: string): void {
+function setComments(comments: vscode.LanguageConfiguration["comments"]): void {
   commentConfig?.dispose();
   commentConfig = vscode.languages.setLanguageConfiguration("tyrano", {
-    comments: { lineComment: token, blockComment: ["/*", "*/"] },
+    comments,
   });
 }
 
 /**
  * Ctrl+/ 用の行コメント切替。
- * iscript ブロック内ではカーソル位置に応じて lineComment を "//" に切り替えてから、
- * VS Code 標準のトグルコマンドを実行する。それ以外は ";"（従来どおり）。
+ * カーソル位置に応じて tyrano 言語の comments 設定を切り替えてから、
+ * VS Code 標準のトグルコマンドを実行する。
+ * - [html]〜[endhtml] ブロック内: ブロックコメント "<!-- -->"（HTML コメント）
+ * - [iscript]〜[endscript] ブロック内: lineComment "//"
+ * - それ以外: lineComment ";"（従来どおり）
+ *
+ * html ブロック内では lineComment を設定しないため、editor.action.commentLine が
+ * blockComment にフォールバックし、各行が "<!-- ... -->" でコメントアウトされる。
  */
 export async function toggleLineComment(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
   if (editor?.document.languageId === "tyrano") {
     const lineNo = editor.selection.active.line;
-    setLineComment(isInsideIscript(editor.document, lineNo) ? "//" : ";");
+    if (isInsideHtml(editor.document, lineNo)) {
+      setComments({ blockComment: ["<!--", "-->"] });
+    } else if (isInsideIscript(editor.document, lineNo)) {
+      setComments({ lineComment: "//", blockComment: ["/*", "*/"] });
+    } else {
+      setComments({ lineComment: ";", blockComment: ["/*", "*/"] });
+    }
   }
   await vscode.commands.executeCommand("editor.action.commentLine");
 }


### PR DESCRIPTION
## Summary
Extended the comment toggle feature (`Ctrl+/`) to support HTML blocks (`[html]`~`[endhtml]`) in addition to existing iscript blocks, allowing context-aware comment syntax selection.

## Key Changes
- **Refactored block detection logic**: Extracted `isInsideIscript()` into a generic `isInsideBlock()` function that accepts start/end tag patterns, reducing code duplication
- **Added HTML block support**: Implemented `isInsideHtml()` function to detect when cursor is inside `[html]`~`[endhtml]` blocks
- **Enhanced comment configuration**: Updated `toggleLineComment()` to set appropriate comment syntax based on context:
  - HTML blocks: Use block comment `<!-- -->` (HTML comments)
  - iscript blocks: Use line comment `//` with block comment `/* */`
  - Other areas: Use line comment `;` (original behavior)
- **Improved function naming**: Renamed `setLineComment()` to `setComments()` to better reflect its expanded responsibility
- **Updated documentation**: Added comprehensive JSDoc comments explaining the new behavior and implementation details

## Implementation Details
The HTML block detection uses the same pattern-matching approach as iscript blocks. When inside an HTML block, only `blockComment` is configured (no `lineComment`), causing VS Code's `editor.action.commentLine` command to fall back to block comment syntax, resulting in HTML-style comments for each line.

https://claude.ai/code/session_011yhmXnDaovMfgULbBLZdg3