### PR TITLE
Fix async iteration and comment parsing bugs, improve formatter idempotency

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -151,7 +151,12 @@ export class Parser {
       if (flag_comment === true && line_str === "*/") {
         flag_comment = false;
       } else if (line_str === "/*" || line_str.startsWith("/**")) {
-        flag_comment = true;
+        // 「/** 説明 */」のように同一行で閉じている場合はブロックコメントを継続しない。
+        // 継続させると以降の全行がコメント扱いになり、診断・補完・ブレークポイントが
+        // 効かなくなる不具合があった。
+        if (!line_str.slice(2).includes("*/")) {
+          flag_comment = true;
+        }
         // } else if (flag_comment == true || first_char === ";") {
       } else if (first_char === "#") {
         var tmp_line = line_str.replace("#", "").trim();

--- a/src/subscriptions/TyranoCompletionItemProvider.ts
+++ b/src/subscriptions/TyranoCompletionItemProvider.ts
@@ -550,32 +550,33 @@ export class TyranoCompletionItemProvider
   > {
     //タグ内のstorage先参照して、そのstorage先にのみ存在するラベルを出力するようにする
     const completions: vscode.CompletionItem[] = [];
-    this.infoWs.labelMap.forEach(async (label, key) => {
+    // forEach に async コールバックを渡すと await されず、push 前に空配列を返してしまうため
+    // for...of で逐次 await する。
+    for (const [key, label] of this.infoWs.labelMap) {
       const labelProjectPath = await this.infoWs.getProjectPathByFilePath(key);
-      if (projectPath === labelProjectPath) {
-        label.forEach((value) => {
-          // storageで指定したファイルに存在するラベルのみ候補に出す
-          // storageがundefinedなら今開いているファイルを指定
-          const storagePath =
-            storage === undefined
-              ? vscode.window.activeTextEditor?.document.uri.fsPath
-              : projectPath +
-                this.infoWs.DATA_DIRECTORY +
-                this.infoWs.DATA_SCENARIO +
-                this.infoWs.pathDelimiter +
-                storage;
-          if (this.infoWs.isSamePath(value.location.uri.fsPath, storagePath!)) {
-            const comp = new vscode.CompletionItem(value.name);
-            comp.kind = vscode.CompletionItemKind.Interface;
-            comp.insertText = "*" + value.name;
-            comp.documentation = new vscode.MarkdownString(
-              `${value.description}`,
-            );
-            completions.push(comp);
-          }
-        });
+      if (projectPath !== labelProjectPath) {
+        continue;
       }
-    });
+      label.forEach((value) => {
+        // storageで指定したファイルに存在するラベルのみ候補に出す
+        // storageがundefinedなら今開いているファイルを指定
+        const storagePath =
+          storage === undefined
+            ? vscode.window.activeTextEditor?.document.uri.fsPath
+            : projectPath +
+              this.infoWs.DATA_DIRECTORY +
+              this.infoWs.DATA_SCENARIO +
+              this.infoWs.pathDelimiter +
+              storage;
+        if (this.infoWs.isSamePath(value.location.uri.fsPath, storagePath!)) {
+          const comp = new vscode.CompletionItem(value.name);
+          comp.kind = vscode.CompletionItemKind.Interface;
+          comp.insertText = "*" + value.name;
+          comp.documentation = new vscode.MarkdownString(`${value.description}`);
+          completions.push(comp);
+        }
+      });
+    }
     return completions;
   }
 

--- a/src/subscriptions/TyranoFormatter.ts
+++ b/src/subscriptions/TyranoFormatter.ts
@@ -24,6 +24,28 @@ function indent(depth: number): string {
 }
 
 /**
+ * 非空行の共通最小インデント（先頭空白文字数）を取り除く。
+ * captureEmbedded 側で改めてインデントが付与されるため、前回付与分をここで
+ * 取り除いておくことで、複数回フォーマットしても段が増殖しない（冪等になる）。
+ */
+function dedentCommon(lines: string[]): string[] {
+  let min = Infinity;
+  for (const line of lines) {
+    if (line.trim() === "") {
+      continue;
+    }
+    const lead = line.length - line.trimStart().length;
+    if (lead < min) {
+      min = lead;
+    }
+  }
+  if (!Number.isFinite(min) || min === 0) {
+    return lines;
+  }
+  return lines.map((line) => (line.trim() === "" ? line : line.slice(min)));
+}
+
+/**
  * 行の先頭タグ名（小文字）を返す。タグでなければ null。
  * @記法は行頭の @tag、[]記法は最初に現れる [tag を対象とする。
  */
@@ -80,7 +102,12 @@ async function formatEmbedded(
     warnings.push(
       `${startLineNo + 1}行目付近の${parser === "babel" ? "JavaScript" : "HTML"}整形に失敗しました: ${message}`,
     );
-    return source.split(/\r?\n/).map((l) => l.replace(/\s+$/, ""));
+    // 整形失敗時は元テキストを返す（; → // 変換も行わない）。
+    // 前回付与済みの共通インデントを取り除いてから返すことで、captureEmbedded 側で
+    // 再びインデントが付与されても段が増殖せず、複数回フォーマットしても安定する。
+    return dedentCommon(innerSource.split(/\r?\n/)).map((l) =>
+      l.replace(/\s+$/, ""),
+    );
   }
 }
 

--- a/src/test/suite/Parser.test.ts
+++ b/src/test/suite/Parser.test.ts
@@ -131,4 +131,40 @@ suite("Parser.parseText", () => {
     assert.strictEqual(macroEntry.pm.name, "multiple_brackets");
   });
 
+  test("1行で閉じる /** */ コメントが以降の行をコメント扱いにしない", () => {
+    const parser = Parser.getInstance();
+    const text = '/** 説明 */\n[jump target="*x"]';
+    const result = parser.parseText(text);
+
+    // /** 説明 */ 自体はコメントとして無視され、配列には入らない
+    // 次行の [jump] はコメントではなく jump タグとして解析されるべき
+    const jumpEntry = result.find((item: any) => item.name === "jump");
+    assert.ok(jumpEntry, "jumpタグがコメント扱いされず解析されるべき");
+    assert.strictEqual(jumpEntry.pm.target, "*x");
+  });
+
+  test("複数行 /* */ ブロックコメント内のタグはコメント扱いになり、閉じた後は通常解析される", () => {
+    const parser = Parser.getInstance();
+    const text = "/*\n[macro name=\"x\"]\n[endmacro]\n*/\n[bg storage=\"a.jpg\"]";
+    const result = parser.parseText(text);
+
+    // コメントブロックを閉じた後の [bg] は通常タグとして解析される
+    const bgEntry = result.find((item: any) => item.name === "bg");
+    assert.ok(bgEntry, "コメントを閉じた後の[bg]が解析されるべき");
+    assert.strictEqual(bgEntry.pm.storage, "a.jpg");
+    // ブロックコメント内の macro はタグとして解析されない
+    const macroEntry = result.find((item: any) => item.name === "macro");
+    assert.ok(!macroEntry, "ブロックコメント内のmacroはタグ扱いされないべき");
+  });
+
+  test("複数行 /** */ ドキュメントコメントも閉じた後は通常解析される", () => {
+    const parser = Parser.getInstance();
+    const text = "/**\nコメント本文\n*/\n[bg storage=\"a.jpg\"]";
+    const result = parser.parseText(text);
+
+    const bgEntry = result.find((item: any) => item.name === "bg");
+    assert.ok(bgEntry, "ドキュメントコメントを閉じた後の[bg]が解析されるべき");
+    assert.strictEqual(bgEntry.pm.storage, "a.jpg");
+  });
+
 });

--- a/src/test/suite/TyranoFormatter.test.ts
+++ b/src/test/suite/TyranoFormatter.test.ts
@@ -243,4 +243,51 @@ suite("TyranoFormatter.formatText", () => {
     const twice = await fmt(once);
     assert.strictEqual(twice, once);
   });
+
+  test("冪等性: 整形に失敗する iscript でもインデントが増殖しない", async () => {
+    const input = ["[iscript]", "this is (((not valid js", "[endscript]"].join(
+      "\n",
+    );
+    const expected = [
+      "[iscript]",
+      "  this is (((not valid js",
+      "[endscript]",
+    ].join("\n");
+    // 何度フォーマットしても 2 スペースのまま（以前は実行のたびに 2 スペースずつ増えていた）
+    let cur = input;
+    for (let i = 0; i < 3; i++) {
+      cur = await fmt(cur);
+      assert.strictEqual(cur, expected, `${i + 1}回目`);
+    }
+  });
+
+  test("冪等性: 整形に失敗する html でもインデントが増殖しない", async () => {
+    const input = ["[html]", "<div><span>hi</div>", "[endhtml]"].join("\n");
+    const once = await fmt(input);
+    const twice = await fmt(once);
+    assert.strictEqual(twice, once);
+    assert.strictEqual(once, ["[html]", "  <div><span>hi</div>", "[endhtml]"].join("\n"));
+  });
+
+  test("冪等性: 失敗する iscript 内の相対インデントは保持される", async () => {
+    const input = [
+      "[iscript]",
+      "function f() {",
+      "  return",
+      "  oops oops",
+      "}",
+      "[endscript]",
+    ].join("\n");
+    const expected = [
+      "[iscript]",
+      "  function f() {",
+      "    return",
+      "    oops oops",
+      "  }",
+      "[endscript]",
+    ].join("\n");
+    const once = await fmt(input);
+    assert.strictEqual(once, expected);
+    assert.strictEqual(await fmt(once), expected);
+  });
 });

--- a/src/test/suite/subscriptions/TyranoCompletionItemProvider.test.ts
+++ b/src/test/suite/subscriptions/TyranoCompletionItemProvider.test.ts
@@ -3,6 +3,7 @@
 // as well as import your extension to test it
 import * as assert from "assert";
 import * as vscode from "vscode";
+import * as path from "path";
 import { TyranoCompletionItemProvider } from "../../../subscriptions/TyranoCompletionItemProvider";
 // import * as path from "path";
 
@@ -537,10 +538,8 @@ suite("TyranoCompletionItemProvider", () => {
         labelMap,
         transitionMap,
         getProjectPathByFilePath: async (_: string) => PROJECT_PATH,
-        isSamePath: (p1: string, p2: string) => {
-          const path = require("path");
-          return path.resolve(p1) === path.resolve(p2);
-        },
+        isSamePath: (p1: string, p2: string) =>
+          path.resolve(p1) === path.resolve(p2),
         DATA_DIRECTORY: "/data",
         DATA_SCENARIO: "/scenario",
         pathDelimiter: "/",
@@ -699,6 +698,100 @@ suite("TyranoCompletionItemProvider", () => {
       assert.ok(
         labels.includes("test2"),
         "storage指定ありのtargetはstorage先ファイルの補完候補に含まれるべき",
+      );
+    });
+  });
+
+  // storage先のラベル補完（completionLabel）テスト
+  suite("completionLabel", () => {
+    const PROJECT_PATH = "/project";
+
+    /** location.uri.fsPath を持つラベルデータを作る */
+    function makeLabel(name: string, fsPath: string) {
+      return {
+        name,
+        description: `${name}の説明`,
+        location: { uri: { fsPath } },
+      };
+    }
+
+    function makeInfoWsMock(
+      labelMap: Map<string, ReturnType<typeof makeLabel>[]>,
+      projectOf: (key: string) => string = () => PROJECT_PATH,
+    ) {
+      return {
+        labelMap,
+        // 実際の I/O のように 1 ティック以上遅延する真の非同期にする。
+        // これにより「forEach(async) で await されない」実装では push 前に
+        // 空配列が返ってしまい、テストが失敗する（＝バグを検出できる）。
+        getProjectPathByFilePath: async (key: string) => {
+          await new Promise((r) => setTimeout(r, 0));
+          return projectOf(key);
+        },
+        isSamePath: (p1: string, p2: string) =>
+          p1 !== undefined &&
+          p2 !== undefined &&
+          path.resolve(p1) === path.resolve(p2),
+        DATA_DIRECTORY: "/data",
+        DATA_SCENARIO: "/scenario",
+        pathDelimiter: "/",
+      };
+    }
+
+    test("正常系 storage先ファイルのラベルが候補に出る（async forEach の await 漏れ回帰）", async () => {
+      const provider = new TyranoCompletionItemProvider();
+      const providerAny = provider as any;
+
+      const STORAGE_FILE = `${PROJECT_PATH}/data/scenario/test.ks`;
+      const OTHER_FILE = `${PROJECT_PATH}/data/scenario/other.ks`;
+      const labelMap = new Map([
+        [
+          STORAGE_FILE,
+          [
+            makeLabel("chapter1", STORAGE_FILE),
+            makeLabel("chapter2", STORAGE_FILE),
+          ],
+        ],
+        [OTHER_FILE, [makeLabel("other_label", OTHER_FILE)]],
+      ]);
+      providerAny.infoWs = makeInfoWsMock(labelMap);
+
+      // storage="test.ks" → storagePath = /project/data/scenario/test.ks
+      const result = await providerAny.completionLabel(PROJECT_PATH, "test.ks");
+
+      assert.ok(Array.isArray(result), "配列が返されるべき");
+      const labels = result.map((item: any) => item.label);
+      // 以前は await されず常に空配列だった
+      assert.ok(
+        labels.includes("chapter1") && labels.includes("chapter2"),
+        "storage先ファイルのラベルが候補に含まれるべき",
+      );
+      assert.ok(
+        !labels.includes("other_label"),
+        "別ファイルのラベルは候補に含まれないべき",
+      );
+    });
+
+    test("正常系 別プロジェクトのラベルは候補に含まれない", async () => {
+      const provider = new TyranoCompletionItemProvider();
+      const providerAny = provider as any;
+
+      const STORAGE_FILE = `${PROJECT_PATH}/data/scenario/test.ks`;
+      const OTHER_PROJECT_FILE = "/other_project/data/scenario/test.ks";
+      const labelMap = new Map([
+        [STORAGE_FILE, [makeLabel("mine", STORAGE_FILE)]],
+        [OTHER_PROJECT_FILE, [makeLabel("theirs", OTHER_PROJECT_FILE)]],
+      ]);
+      providerAny.infoWs = makeInfoWsMock(labelMap, (key) =>
+        key.startsWith("/other_project") ? "/other_project" : PROJECT_PATH,
+      );
+
+      const result = await providerAny.completionLabel(PROJECT_PATH, "test.ks");
+      const labels = result.map((item: any) => item.label);
+      assert.ok(labels.includes("mine"), "同一プロジェクトのラベルは含まれるべき");
+      assert.ok(
+        !labels.includes("theirs"),
+        "別プロジェクトのラベルは含まれないべき",
       );
     });
   });


### PR DESCRIPTION
## Summary
This PR fixes critical bugs in label completion, comment parsing, and formatter idempotency, along with improving code quality.

## Key Changes

### TyranoCompletionItemProvider - Fix async iteration bug
- **Critical fix**: Changed `forEach(async)` to `for...of` loop in `completionLabel()` method
  - The previous implementation used `forEach` with an async callback, which doesn't await the async operation
  - This caused the method to return an empty array before labels were processed
  - Now properly awaits `getProjectPathByFilePath()` for each label entry
- Added comprehensive test cases to detect this regression:
  - Test for storage file labels appearing in completions
  - Test for filtering labels by project path
- Refactored mock setup to use true async delays, making the bug detectable in tests
- Moved `path` import to top level for cleaner code

### Parser - Fix single-line comment handling
- Fixed bug where `/** comment */` on a single line would incorrectly mark all subsequent lines as comments
- Added check: only set `flag_comment = true` if the closing `*/` is not on the same line
- Added test cases:
  - Single-line `/** */` comments don't affect following lines
  - Multi-line `/* */` block comments properly close and resume parsing
  - Multi-line `/** */` doc comments properly close and resume parsing

### TyranoFormatter - Fix indentation proliferation
- Added `dedentCommon()` function to remove common leading whitespace from embedded content
- This ensures formatter idempotency: formatting the same text multiple times produces identical output
- When formatting fails (invalid JS/HTML), the function now:
  - Returns the original text without modification
  - Removes previously-applied indentation to prevent accumulation
  - Allows `captureEmbedded()` to re-apply indentation without duplication
- Added test cases verifying idempotency:
  - Invalid JavaScript in `[iscript]` blocks
  - Invalid HTML in `[html]` blocks
  - Relative indentation preservation in failed formatting

## Implementation Details
- The async iteration fix uses `for...of` with explicit `await`, which is the standard pattern for sequential async operations
- Comment parsing now checks for closing delimiter on the same line before entering comment mode
- Formatter idempotency is achieved by normalizing indentation before re-applying it, rather than accumulating layers

https://claude.ai/code/session_017tHX9Y7rVpXX6szyEp1xtW