### PR TITLE
潜在バグを修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tyranosyntax",
-  "version": "3.0.0",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tyranosyntax",
-      "version": "3.0.0",
+      "version": "3.1.2",
       "dependencies": {
         "@babel/parser": "^7.24.6",
         "@babel/traverse": "^7.24.6",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -49,7 +49,7 @@ async function getAllKsFiles(workspacePath: string): Promise<string[]> {
     const fullPath = path.join(workspacePath, file);
     const stat = fs.statSync(fullPath);
     if (stat.isDirectory()) {
-      getAllKsFiles(fullPath);
+      results.push(...(await getAllKsFiles(fullPath)));
     } else if (file.endsWith(".ks")) {
       results.push(fullPath);
     }

--- a/src/subscriptions/MacroTablePanel.ts
+++ b/src/subscriptions/MacroTablePanel.ts
@@ -118,7 +118,7 @@ export class MacroTablePanel {
               preserveFocus: false,
             });
             res.json({ ok: true });
-          } catch (error) {
+          } catch (_error) {
             TyranoLogger.print(
               `MacroTablePanel open-file failed for ${filePath}`,
               ErrorLevel.WARN,
@@ -138,7 +138,7 @@ export class MacroTablePanel {
 
     if (MacroTablePanel.serverInstance) {
       MacroTablePanel.serverInstance.close(() => {
-        console.log("port 3300 server closed");
+        console.log("port 3400 server closed");
       });
     }
 
@@ -149,7 +149,7 @@ export class MacroTablePanel {
         cancellable: true,
       },
       async () => {
-        createServer();
+        await createServer();
       },
     );
   }

--- a/src/subscriptions/TyranoHoverProvider.ts
+++ b/src/subscriptions/TyranoHoverProvider.ts
@@ -15,7 +15,7 @@ export class TyranoHoverProvider {
       fs.readFileSync(this.getTooltipPath(), "utf8"),
     );
     // this.regExp = /(\w+)(\s*((\w*)=\"?([a-zA-Z0-9_./\*]*)\"?)*)*/;//取得した行に対しての正規表現	//タグのどこをホバーしてもツールチップ出る版
-    this.regExp = /(\[||@)(\w+)(\s*)/; //取得した行に対しての正規表現 //タグ名のみホバーでツールチップ出る版
+    this.regExp = /(\[|@)(\w+)(\s*)/; //取得した行に対しての正規表現 //タグ名のみホバーでツールチップ出る版
   }
 
   private getTooltipPath(): string {

--- a/src/subscriptions/TyranoJumpProvider.ts
+++ b/src/subscriptions/TyranoJumpProvider.ts
@@ -83,6 +83,14 @@ export class TyranoJumpProvider {
     //F12押した付近のタグのデータを取得
     const tagIndex = parser.getIndex(parsedData, position.character);
 
+    //カーソル位置にタグがないなら何もしない
+    if (tagIndex === undefined || parsedData[tagIndex] === undefined) {
+      vscode.window.showWarningMessage(
+        "現在選択しているタグはTyranoScript syntax.jump.tagに登録されているタグではありません。\nsetting.jsonをご確認ください。",
+      );
+      return;
+    }
+
     //カーソル位置のタグ名取得
     const tagName = parsedData[tagIndex]["name"];
 
@@ -102,7 +110,16 @@ export class TyranoJumpProvider {
     //カーソルの位置のタグがジャンプ系タグなら
     if (Object.keys(jumpTagObject).includes(tagName)) {
       //変数を使っている場合はジャンプさせない
-      const variableStr = /&f\.|&sf\.|&tf\.|&mp\|/;
+      const variableStr = /&f\.|&sf\.|&tf\.|&mp\./;
+      if (
+        jumpStorage.search(variableStr) !== -1 ||
+        (jumpTarget !== undefined && jumpTarget.search(variableStr) !== -1)
+      ) {
+        vscode.window.showInformationMessage(
+          "storageやtargetパラメータに変数を使用しているためジャンプできません。",
+        );
+        return;
+      }
       if (
         !fs.existsSync(
           vscode.Uri.file(
@@ -111,7 +128,7 @@ export class TyranoJumpProvider {
         )
       ) {
         vscode.window.showWarningMessage(
-          `${parsedData[tagIndex]["pm"]["storage"]}は存在しないファイルです。`,
+          `${jumpStorage}は存在しないファイルです。`,
         );
         return;
       }
@@ -133,17 +150,6 @@ export class TyranoJumpProvider {
             new vscode.Position(0, 0),
             new vscode.Position(0, 0),
           ),
-        );
-        return;
-      }
-
-      //変数ならジャンプさせない
-      if (
-        jumpStorage.search(variableStr) !== -1 ||
-        jumpTarget.search(variableStr) !== -1
-      ) {
-        vscode.window.showInformationMessage(
-          "storageやtargetパラメータに変数を使用しているためジャンプできません。",
         );
         return;
       }

--- a/src/subscriptions/TyranoPreview.ts
+++ b/src/subscriptions/TyranoPreview.ts
@@ -308,7 +308,7 @@ export class TyranoPreview {
         cancellable: true,
       },
       async (_progress, _token) => {
-        createServer();
+        await createServer();
       },
     );
   }

--- a/src/test/suite/subscriptions/TyranoCompletionItemProvider.test.ts
+++ b/src/test/suite/subscriptions/TyranoCompletionItemProvider.test.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { TyranoCompletionItemProvider } from "../../../subscriptions/TyranoCompletionItemProvider";
-// import * as path from "path";
+import * as nodePath from "path";
 
 // // 新しく追加した型定義のテスト用
 // type TagParameterConfig = {
@@ -538,8 +538,7 @@ suite("TyranoCompletionItemProvider", () => {
         transitionMap,
         getProjectPathByFilePath: async (_: string) => PROJECT_PATH,
         isSamePath: (p1: string, p2: string) => {
-          const path = require("path");
-          return path.resolve(p1) === path.resolve(p2);
+          return nodePath.resolve(p1) === nodePath.resolve(p2);
         },
         DATA_DIRECTORY: "/data",
         DATA_SCENARIO: "/scenario",


### PR DESCRIPTION
- TyranoHoverProvider: 正規表現の空選択肢(\[||@)により地の文の単語でもツールチップが表示されるバグを修正
- server/server.ts: getAllKsFilesがサブディレクトリの.ksファイルを収集できていなかったバグを修正
- TyranoPreview/MacroTablePanel: withProgress内でcreateServerをawaitしておらず進捗表示が即終了するバグを修正
- MacroTablePanel: サーバークローズ時のログのポート番号誤記(3300→3400)を修正
- lintエラー2件を修正しnpm testが実行可能な状態に復旧(未使用変数、require文)

https://claude.ai/code/session_01Si32ibby2rQGWKHXds9UpT