### PR TITLE
タグ補完の速度を改善

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "tyranosyntax" extension will be documented in this f
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [3.2.1] 2026-07-11
+
+- タグ補完候補のキャッシュ、プロジェクトルートの解決、パラメータ補完を改善し、タグ補完を繰り返し実行した際の応答速度を改善しました。[#419](https://github.com/orukRed/tyranosyntax/pull/419)
+
 ## [3.2.0] 2026-06-11
 
 - .ksファイルのコードフォーマット機能を追加しました。VS Code標準の「ドキュメントのフォーマット」（`Shift+Alt+F`）で以下の整形が行われます。

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/orukRed/tyranosyntax"
   },
   "icon": "images/icon.png",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "engines": {
     "vscode": "^1.79.1"
   },

--- a/src/InformationWorkSpace.ts
+++ b/src/InformationWorkSpace.ts
@@ -1344,7 +1344,29 @@ export class InformationWorkSpace {
       }
     }
 
-    return matchedProjectPath;
+    if (!matchedProjectPath) {
+      return undefined;
+    }
+
+    const resolvedMatchedProjectPath = path.resolve(matchedProjectPath);
+    let searchDirectory = path.dirname(resolvedFilePath);
+
+    for (;;) {
+      const isKnownProjectRoot =
+        path.relative(resolvedMatchedProjectPath, searchDirectory) === "";
+      if (fs.existsSync(path.join(searchDirectory, "index.html"))) {
+        return isKnownProjectRoot ? matchedProjectPath : searchDirectory;
+      }
+      if (isKnownProjectRoot) {
+        return undefined;
+      }
+
+      const parentDirectory = path.dirname(searchDirectory);
+      if (parentDirectory === searchDirectory) {
+        return undefined;
+      }
+      searchDirectory = parentDirectory;
+    }
   }
 
   /**

--- a/src/InformationWorkSpace.ts
+++ b/src/InformationWorkSpace.ts
@@ -62,6 +62,8 @@ export class InformationWorkSpace {
   >(); //projectpath,変数名と、定義情報
   private _labelMap: Map<string, LabelData[]> = new Map<string, LabelData[]>(); //ファイルパス、LabelDataの配列
   private _suggestions: Map<string, object> = new Map<string, object>(); //projectPath,入力候補のオブジェクト
+  private _suggestionVersions: Map<string, number> = new Map<string, number>();
+  private _suggestionVersionCounter = 0;
   private _characterMap: Map<string, CharacterData[]> = new Map<
     string,
     CharacterData[]
@@ -107,6 +109,41 @@ export class InformationWorkSpace {
   public static getInstance(): InformationWorkSpace {
     return this.instance;
   }
+
+  private markSuggestionsUpdated(projectPath: string): void {
+    this._suggestionVersions.set(projectPath, ++this._suggestionVersionCounter);
+  }
+
+  private setSuggestionsForProject(
+    projectPath: string,
+    suggestions: object,
+  ): void {
+    this._suggestions.set(projectPath, suggestions);
+    this.markSuggestionsUpdated(projectPath);
+  }
+
+  private addSuggestion(
+    projectPath: string,
+    tagName: string,
+    suggestion: unknown,
+  ): void {
+    const suggestions = this._suggestions.get(projectPath) as
+      | Record<string, unknown>
+      | undefined;
+    if (!suggestions) return;
+
+    suggestions[tagName] = suggestion;
+    this.markSuggestionsUpdated(projectPath);
+  }
+
+  /**
+   * 指定プロジェクトのタグ候補が最後に更新された世代を返す。
+   * 補完候補キャッシュの無効化に利用する。
+   */
+  public getSuggestionVersion(projectPath: string): number {
+    return this._suggestionVersions.get(projectPath) ?? 0;
+  }
+
   private getSnippetPath(): string {
     return InformationExtension.language === "ja"
       ? path.join(
@@ -144,7 +181,7 @@ export class InformationWorkSpace {
 
         this.defaultTagList = Object.keys(parsedJson);
         this.defaultTagList.push(...Object.keys(this.pluginTags)); //pluginTagsをdefaultTagListに追加
-        this.suggestions.set(projectPath, combinedObject);
+        this.setSuggestionsForProject(projectPath, combinedObject);
         if (Object.keys(this.suggestions.get(projectPath)!).length === 0) {
           throw new Error("suggestions is empty");
         }
@@ -468,8 +505,11 @@ export class InformationWorkSpace {
                     macroName,
                   )
                 ) {
-                  this._suggestions.get(projectPath)![macroName] =
-                    macroData.parseToJsonObject();
+                  this.addSuggestion(
+                    projectPath,
+                    macroName,
+                    macroData.parseToJsonObject(),
+                  );
                 }
               }
             }
@@ -933,8 +973,11 @@ export class InformationWorkSpace {
                 macroData.macroName,
               )
             ) {
-              this._suggestions.get(projectPath)![macroData.macroName] =
-                macroData.parseToJsonObject();
+              this.addSuggestion(
+                projectPath,
+                macroData.macroName,
+                macroData.parseToJsonObject(),
+              );
             }
           }
           isMacro = false; //macro-endmacro間であることを判定
@@ -1193,10 +1236,21 @@ export class InformationWorkSpace {
       (tag) => !this.defaultTagList.includes(tag),
     );
 
-    if (0 < filteredDeleteTagList.length) {
-      filteredDeleteTagList.forEach((tag) => {
-        delete this.suggestions.get(projectPath)![tag];
-      });
+    const suggestions = this.suggestions.get(projectPath) as
+      | Record<string, unknown>
+      | undefined;
+    if (!suggestions) return;
+
+    let hasDeletedSuggestion = false;
+    filteredDeleteTagList.forEach((tag) => {
+      if (Object.prototype.hasOwnProperty.call(suggestions, tag)) {
+        delete suggestions[tag];
+        hasDeletedSuggestion = true;
+      }
+    });
+
+    if (hasDeletedSuggestion) {
+      this.markSuggestionsUpdated(projectPath);
     }
   }
   /**
@@ -1268,12 +1322,42 @@ export class InformationWorkSpace {
     return ret;
   }
 
+  private getKnownProjectPathByFilePath(filePath: string): string | undefined {
+    const resolvedFilePath = path.resolve(filePath);
+    let matchedProjectPath: string | undefined;
+
+    for (const projectPath of this._suggestions.keys()) {
+      const relativePath = path.relative(
+        path.resolve(projectPath),
+        resolvedFilePath,
+      );
+      const isOutsideProject =
+        relativePath === ".." ||
+        relativePath.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relativePath);
+
+      if (
+        !isOutsideProject &&
+        (!matchedProjectPath || projectPath.length > matchedProjectPath.length)
+      ) {
+        matchedProjectPath = projectPath;
+      }
+    }
+
+    return matchedProjectPath;
+  }
+
   /**
    * 引数で指定したファイルパスからプロジェクトパス（index.htmlのあるフォルダパス）を取得します。
    * @param filePath
    * @returns
    */
   public async getProjectPathByFilePath(filePath: string): Promise<string> {
+    const knownProjectPath = this.getKnownProjectPathByFilePath(filePath);
+    if (knownProjectPath) {
+      return knownProjectPath;
+    }
+
     let searchDir;
     do {
       const delimiterIndex = filePath.lastIndexOf(this.pathDelimiter);
@@ -1301,6 +1385,11 @@ export class InformationWorkSpace {
    * @returns
    */
   private getProjectPathByFilePathSync(filePath: string): string {
+    const knownProjectPath = this.getKnownProjectPathByFilePath(filePath);
+    if (knownProjectPath) {
+      return knownProjectPath;
+    }
+
     let searchDir;
     do {
       const delimiterIndex = filePath.lastIndexOf(this.pathDelimiter);
@@ -1494,6 +1583,10 @@ export class InformationWorkSpace {
   }
   public set suggestions(value: Map<string, object>) {
     this._suggestions = value;
+    this._suggestionVersions.clear();
+    for (const projectPath of value.keys()) {
+      this.markSuggestionsUpdated(projectPath);
+    }
   }
   public get extensionPath() {
     return this._extensionPath;

--- a/src/subscriptions/TyranoCompletionItemProvider.ts
+++ b/src/subscriptions/TyranoCompletionItemProvider.ts
@@ -8,7 +8,9 @@ import * as fs from "fs";
 
 type SuggestionsMiniumByTag = {
   [tag: string]: {
-    [s: string]: string;
+    name?: string;
+    description?: string;
+    [s: string]: unknown;
   };
 };
 
@@ -31,6 +33,13 @@ type TagParameterConfig = {
   values?: string[];
 };
 
+type TagCompletionStyle = "plain" | "at" | "bracket";
+
+type TagCompletionCacheEntry = {
+  suggestionVersion: number;
+  completionsByStyle: Map<TagCompletionStyle, vscode.CompletionItem[]>;
+};
+
 export class TyranoCompletionItemProvider
   implements vscode.CompletionItemProvider
 {
@@ -41,6 +50,10 @@ export class TyranoCompletionItemProvider
   private readonly PARAM_REGEXP = new RegExp('(\\S)+="(?![\\s\\S]*")', "g");
   private readonly VARIABLE_REGEXP = /&?(f\.|sf\.|tf\.|mp\.)(\S)*$/;
   private readonly SHARP_REGEXP = /\s*#.*$/;
+  private readonly tagCompletionCache = new WeakMap<
+    SuggestionsMiniumByTag,
+    TagCompletionCacheEntry
+  >();
 
   public constructor() {}
   private tagParams: {
@@ -746,53 +759,48 @@ export class TyranoCompletionItemProvider
     }
 
     // 既存のリソースファイル処理（image, scenario等）
-    this.infoWs.resourceFileMap.forEach((resourcesMap, key) => {
-      if (projectPath === key) {
-        resourcesMap.forEach((resource) => {
-          if (typeArray.includes(resource.resourceType)) {
-            const comp = new vscode.CompletionItem({
-              label: resource.filePath
-                .replace(
-                  projectPath +
-                    this.infoWs.DATA_DIRECTORY +
-                    this.infoWs.pathDelimiter,
-                  "",
-                )
-                .replace(/\\/g, "/"),
-              description: resource.filePath.replace(
-                projectPath + this.infoWs.pathDelimiter,
-                "",
-              ),
-              detail: "",
-            });
-            comp.kind = vscode.CompletionItemKind.File;
-            const referenceFilePath = path
-              .relative(referencePath, resource.filePath)
-              .replace(/\\/g, "/"); //基準パスからの相対パス
+    const resources = this.infoWs.resourceFileMap.get(projectPath);
+    if (!resources) return completions;
 
-            // MarkdownStringの設定（baseUriを先に設定する必要がある）
-            comp.documentation = new vscode.MarkdownString();
-            comp.documentation.baseUri = vscode.Uri.file(
-              referencePath + path.sep,
-            );
-            comp.documentation.supportHtml = true;
-            comp.documentation.isTrusted = true;
-            comp.documentation.supportThemeIcons = true;
-
-            // 画像の絶対パスを作成
-            const absoluteImagePath = vscode.Uri.file(
-              resource.filePath,
-            ).toString();
-
-            comp.documentation.appendMarkdown(`${referenceFilePath}<br>`);
-            comp.documentation.appendMarkdown(
-              `<img src="${absoluteImagePath}" width=350>`,
-            );
-
-            comp.insertText = new vscode.SnippetString(referenceFilePath); //基準パスからの相対パス
-            completions.push(comp);
-          }
+    resources.forEach((resource) => {
+      if (typeArray.includes(resource.resourceType)) {
+        const comp = new vscode.CompletionItem({
+          label: resource.filePath
+            .replace(
+              projectPath +
+                this.infoWs.DATA_DIRECTORY +
+                this.infoWs.pathDelimiter,
+              "",
+            )
+            .replace(/\\/g, "/"),
+          description: resource.filePath.replace(
+            projectPath + this.infoWs.pathDelimiter,
+            "",
+          ),
+          detail: "",
         });
+        comp.kind = vscode.CompletionItemKind.File;
+        const referenceFilePath = path
+          .relative(referencePath, resource.filePath)
+          .replace(/\\/g, "/"); //基準パスからの相対パス
+
+        // MarkdownStringの設定（baseUriを先に設定する必要がある）
+        comp.documentation = new vscode.MarkdownString();
+        comp.documentation.baseUri = vscode.Uri.file(referencePath + path.sep);
+        comp.documentation.supportHtml = true;
+        comp.documentation.isTrusted = true;
+        comp.documentation.supportThemeIcons = true;
+
+        // 画像の絶対パスを作成
+        const absoluteImagePath = vscode.Uri.file(resource.filePath).toString();
+
+        comp.documentation.appendMarkdown(`${referenceFilePath}<br>`);
+        comp.documentation.appendMarkdown(
+          `<img src="${absoluteImagePath}" width=350>`,
+        );
+
+        comp.insertText = new vscode.SnippetString(referenceFilePath); //基準パスからの相対パス
+        completions.push(comp);
       }
     });
     return completions;
@@ -844,9 +852,23 @@ export class TyranoCompletionItemProvider
         ? lineText.charAt(position.character)
         : "";
 
-    const suggestions = structuredClone(
-      this.infoWs.suggestions.get(projectPath),
-    ) as SuggestionsByTag; // TODO: Don't use type assertion //タグ補完に使うタグのリスト
+    const suggestions = this.infoWs.suggestions.get(projectPath) as
+      | SuggestionsByTag
+      | undefined; // TODO: Don't use type assertion //タグ補完に使うタグのリスト
+    if (!suggestions) {
+      return completions;
+    }
+    const selectedTagKey = Object.prototype.hasOwnProperty.call(
+      suggestions,
+      selectedTag,
+    )
+      ? selectedTag
+      : Object.keys(suggestions).find(
+          (tagKey) => suggestions[tagKey]["name"]?.toString() === selectedTag,
+        );
+    if (!selectedTagKey) {
+      return completions;
+    }
     const partList = this.getPartListFromCharacterData(
       projectPath,
       nameParamValue,
@@ -854,21 +876,22 @@ export class TyranoCompletionItemProvider
     //item:{}で囲ったタグの番号。0,1,2,3...
     //name:そのまんま。middle.jsonを見て。
     //item2:タグのパラメータ。0,1,2,3...って順に。
-    for (const item in suggestions) {
+    for (const item of [selectedTagKey]) {
       const tagName = suggestions[item]["name"]?.toString(); //タグ名。jumpとかpとかimageとか。
       if (selectedTag === tagName) {
+        const parameterSuggestions = [...suggestions[item]["parameters"]];
         //nameの値によって、追加するパラメータを変更する。
         //chara_partタグなら特別にCharacterDataに存在するpartの値を追加する。
         if (selectedTag === "chara_part") {
           partList.forEach((part) => {
-            suggestions[item]["parameters"].push({
+            parameterSuggestions.push({
               name: part,
               description: "chara_layerタグのpartパラメータで指定した値",
               required: false,
             });
           });
         }
-        for (const item2 of suggestions[item]["parameters"]) {
+        for (const item2 of parameterSuggestions) {
           if (!(item2["name"] in parameters)) {
             //タグにないparameterのみインテリセンスに出す
             let detailText = "";
@@ -922,6 +945,9 @@ export class TyranoCompletionItemProvider
     const suggestionsByTag = this.infoWs.suggestions.get(
       projectPath,
     ) as SuggestionsMiniumByTag; // FIXME: Don't use type assertion
+    if (!suggestionsByTag) {
+      return completions;
+    }
 
     // 現在の行の内容を取得
     const lineText = document.lineAt(position.line).text;
@@ -936,6 +962,32 @@ export class TyranoCompletionItemProvider
     const isInsideBrackets =
       lastOpenBracket > lastCloseBracket && lastOpenBracket !== -1;
 
+    const inputType =
+      vscode.workspace
+        .getConfiguration()
+        .get<string>("TyranoScript syntax.completionTag.inputType") ?? "[ ]";
+    const completionStyle: TagCompletionStyle =
+      hasAtSymbol || isInsideBrackets
+        ? "plain"
+        : inputType === "@"
+          ? "at"
+          : "bracket";
+    const suggestionVersion = this.infoWs.getSuggestionVersion(projectPath);
+    let cacheEntry = this.tagCompletionCache.get(suggestionsByTag);
+    if (!cacheEntry || cacheEntry.suggestionVersion !== suggestionVersion) {
+      cacheEntry = {
+        suggestionVersion,
+        completionsByStyle: new Map(),
+      };
+      this.tagCompletionCache.set(suggestionsByTag, cacheEntry);
+    }
+
+    const cachedCompletions =
+      cacheEntry.completionsByStyle.get(completionStyle);
+    if (cachedCompletions) {
+      return cachedCompletions;
+    }
+
     for (const suggestion of Object.values(suggestionsByTag)) {
       if (!suggestion.name) continue;
       const { name, description } = suggestion;
@@ -943,10 +995,6 @@ export class TyranoCompletionItemProvider
         // FIXME: Make the `try`-block smaller[]
         const textLabel = name.toString();
         const comp = new vscode.CompletionItem(textLabel);
-        const inputType = vscode.workspace
-          .getConfiguration()
-          .get("TyranoScript syntax.completionTag.inputType");
-
         // insertTextを動的に決定
         let insertText: string;
         if (hasAtSymbol) {
@@ -977,6 +1025,7 @@ export class TyranoCompletionItemProvider
         TyranoLogger.printStackTrace(error);
       }
     }
+    cacheEntry.completionsByStyle.set(completionStyle, completions);
     return completions;
   }
 
@@ -993,40 +1042,40 @@ export class TyranoCompletionItemProvider
     const dataDir =
       projectPath + this.infoWs.DATA_DIRECTORY + this.infoWs.pathDelimiter;
 
-    this.infoWs.resourceFileMap.forEach((resourcesMap, key) => {
-      if (projectPath !== key) return;
-      resourcesMap.forEach((resource) => {
-        // data/ 以降の相対パス (例: "bgimage\room.jpg")
-        const relFromData = resource.filePath.startsWith(dataDir)
-          ? resource.filePath.slice(dataDir.length)
-          : path.relative(dataDir, resource.filePath);
-        const segments = relFromData.split(path.sep);
-        // 最初のセグメントがリソースフォルダ名 (例: "bgimage")
-        // 挿入テキストはそれ以降 (例: "room.jpg")
-        const insertText = segments.slice(1).join("/");
-        if (!insertText) return; // data直下のファイルは除外
+    const resources = this.infoWs.resourceFileMap.get(projectPath);
+    if (!resources) return completions;
 
-        const comp = new vscode.CompletionItem({
-          label: insertText,
-          description: relFromData.replace(/\\/g, "/"),
-        });
-        comp.kind = vscode.CompletionItemKind.File;
-        comp.insertText = new vscode.SnippetString(insertText);
+    resources.forEach((resource) => {
+      // data/ 以降の相対パス (例: "bgimage\room.jpg")
+      const relFromData = resource.filePath.startsWith(dataDir)
+        ? resource.filePath.slice(dataDir.length)
+        : path.relative(dataDir, resource.filePath);
+      const segments = relFromData.split(path.sep);
+      // 最初のセグメントがリソースフォルダ名 (例: "bgimage")
+      // 挿入テキストはそれ以降 (例: "room.jpg")
+      const insertText = segments.slice(1).join("/");
+      if (!insertText) return; // data直下のファイルは除外
 
-        const absoluteImagePath = vscode.Uri.file(resource.filePath).toString();
-        comp.documentation = new vscode.MarkdownString();
-        comp.documentation.baseUri = vscode.Uri.file(
-          path.dirname(resource.filePath) + path.sep,
-        );
-        comp.documentation.supportHtml = true;
-        comp.documentation.isTrusted = true;
-        comp.documentation.appendMarkdown(`${insertText}<br>`);
-        comp.documentation.appendMarkdown(
-          `<img src="${absoluteImagePath}" width=350>`,
-        );
-
-        completions.push(comp);
+      const comp = new vscode.CompletionItem({
+        label: insertText,
+        description: relFromData.replace(/\\/g, "/"),
       });
+      comp.kind = vscode.CompletionItemKind.File;
+      comp.insertText = new vscode.SnippetString(insertText);
+
+      const absoluteImagePath = vscode.Uri.file(resource.filePath).toString();
+      comp.documentation = new vscode.MarkdownString();
+      comp.documentation.baseUri = vscode.Uri.file(
+        path.dirname(resource.filePath) + path.sep,
+      );
+      comp.documentation.supportHtml = true;
+      comp.documentation.isTrusted = true;
+      comp.documentation.appendMarkdown(`${insertText}<br>`);
+      comp.documentation.appendMarkdown(
+        `<img src="${absoluteImagePath}" width=350>`,
+      );
+
+      completions.push(comp);
     });
     return completions;
   }

--- a/src/test/suite/InformationWorkSpaceCompletionCache.test.ts
+++ b/src/test/suite/InformationWorkSpaceCompletionCache.test.ts
@@ -1,27 +1,34 @@
 import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 import { InformationWorkSpace } from "../../InformationWorkSpace";
 
 suite("InformationWorkSpace completion fast paths", () => {
-  test("uses the deepest known project root for a file", async () => {
+  test("prefers a newly-created nested project over a known parent root", async () => {
     const info = InformationWorkSpace.getInstance();
     const originalSuggestions = info.suggestions;
-    const parentProjectPath = path.resolve("issue416-parent-project");
+    const testDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), "tyranosyntax-issue416-"),
+    );
+    const parentProjectPath = path.join(testDirectory, "parent-project");
     const nestedProjectPath = path.join(parentProjectPath, "nested-project");
+    const scenarioDirectory = path.join(nestedProjectPath, "data", "scenario");
 
     try {
-      info.suggestions = new Map([
-        [parentProjectPath, {}],
-        [nestedProjectPath, {}],
-      ]);
+      fs.mkdirSync(scenarioDirectory, { recursive: true });
+      fs.writeFileSync(path.join(parentProjectPath, "index.html"), "");
+      fs.writeFileSync(path.join(nestedProjectPath, "index.html"), "");
+      info.suggestions = new Map([[parentProjectPath, {}]]);
 
       const projectPath = await info.getProjectPathByFilePath(
-        path.join(nestedProjectPath, "data", "scenario", "scene.ks"),
+        path.join(scenarioDirectory, "scene.ks"),
       );
 
       assert.strictEqual(projectPath, nestedProjectPath);
     } finally {
       info.suggestions = originalSuggestions;
+      fs.rmSync(testDirectory, { recursive: true, force: true });
     }
   });
 

--- a/src/test/suite/InformationWorkSpaceCompletionCache.test.ts
+++ b/src/test/suite/InformationWorkSpaceCompletionCache.test.ts
@@ -1,0 +1,66 @@
+import * as assert from "assert";
+import * as path from "path";
+import { InformationWorkSpace } from "../../InformationWorkSpace";
+
+suite("InformationWorkSpace completion fast paths", () => {
+  test("uses the deepest known project root for a file", async () => {
+    const info = InformationWorkSpace.getInstance();
+    const originalSuggestions = info.suggestions;
+    const parentProjectPath = path.resolve("issue416-parent-project");
+    const nestedProjectPath = path.join(parentProjectPath, "nested-project");
+
+    try {
+      info.suggestions = new Map([
+        [parentProjectPath, {}],
+        [nestedProjectPath, {}],
+      ]);
+
+      const projectPath = await info.getProjectPathByFilePath(
+        path.join(nestedProjectPath, "data", "scenario", "scene.ks"),
+      );
+
+      assert.strictEqual(projectPath, nestedProjectPath);
+    } finally {
+      info.suggestions = originalSuggestions;
+    }
+  });
+
+  test("increments the suggestion version when a dynamic tag is removed", async () => {
+    const info = InformationWorkSpace.getInstance();
+    const originalSuggestions = info.suggestions;
+    const projectPath = path.resolve("issue416-version-project");
+
+    try {
+      info.suggestions = new Map([
+        [
+          projectPath,
+          {
+            issue416_dynamic_tag: {
+              name: "issue416_dynamic_tag",
+              description: "dynamic tag",
+              parameters: [],
+            },
+          },
+        ],
+      ]);
+      const previousVersion = info.getSuggestionVersion(projectPath);
+
+      await info.spliceSuggestionsByFilePath(projectPath, [
+        "issue416_dynamic_tag",
+      ]);
+
+      assert.ok(
+        info.getSuggestionVersion(projectPath) > previousVersion,
+        "removing a dynamic tag should invalidate tag completion candidates",
+      );
+      assert.strictEqual(
+        (info.suggestions.get(projectPath) as Record<string, unknown>)[
+          "issue416_dynamic_tag"
+        ],
+        undefined,
+      );
+    } finally {
+      info.suggestions = originalSuggestions;
+    }
+  });
+});

--- a/src/test/suite/subscriptions/TyranoCompletionItemProviderPerformance.test.ts
+++ b/src/test/suite/subscriptions/TyranoCompletionItemProviderPerformance.test.ts
@@ -168,7 +168,7 @@ suite("TyranoCompletionItemProvider performance behavior", () => {
     assert.strictEqual(getInsertText(bracketResult[0]), "p $0");
     assert.strictEqual(getInsertText(atResult[0]), "p $0");
     assert.notStrictEqual(normalResult, bracketResult);
-    assert.notStrictEqual(bracketResult, atResult);
+    assert.strictEqual(bracketResult, atResult);
   });
 
   test("does not mutate chara_part suggestions while adding dynamic parts", async () => {

--- a/src/test/suite/subscriptions/TyranoCompletionItemProviderPerformance.test.ts
+++ b/src/test/suite/subscriptions/TyranoCompletionItemProviderPerformance.test.ts
@@ -1,0 +1,226 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { TyranoCompletionItemProvider } from "../../../subscriptions/TyranoCompletionItemProvider";
+
+type TestableCompletionProvider = {
+  infoWs: unknown;
+  completionTag: (
+    projectPath: string,
+    document: vscode.TextDocument,
+    position: vscode.Position,
+  ) => Promise<vscode.CompletionItem[]>;
+  completionParameter: (
+    selectedTag: string,
+    parameters: object,
+    projectPath: string,
+    nameParamValue: string,
+    document: vscode.TextDocument,
+    position: vscode.Position,
+  ) => Promise<vscode.CompletionItem[]>;
+};
+
+function createMockDocument(lineText: string): vscode.TextDocument {
+  return {
+    uri: vscode.Uri.file("/project/data/scenario/test.ks"),
+    fileName: "/project/data/scenario/test.ks",
+    isUntitled: false,
+    languageId: "tyrano",
+    version: 1,
+    isDirty: false,
+    isClosed: false,
+    eol: vscode.EndOfLine.LF,
+    lineCount: 1,
+    save: () => Promise.resolve(true),
+    lineAt: (_: number | vscode.Position) => ({
+      lineNumber: 0,
+      text: lineText,
+      range: new vscode.Range(0, 0, 0, lineText.length),
+      rangeIncludingLineBreak: new vscode.Range(0, 0, 1, 0),
+      firstNonWhitespaceCharacterIndex: lineText.search(/\S/),
+      isEmptyOrWhitespace: lineText.trim() === "",
+    }),
+    offsetAt: () => 0,
+    positionAt: () => new vscode.Position(0, 0),
+    getText: () => lineText,
+    getWordRangeAtPosition: () => undefined,
+    validateRange: (range: vscode.Range) => range,
+    validatePosition: (position: vscode.Position) => position,
+  } as vscode.TextDocument;
+}
+
+function getCompletionLabel(item: vscode.CompletionItem): string {
+  return typeof item.label === "string" ? item.label : item.label.label;
+}
+
+function getInsertText(item: vscode.CompletionItem): string | undefined {
+  return item.insertText instanceof vscode.SnippetString
+    ? item.insertText.value
+    : item.insertText;
+}
+
+suite("TyranoCompletionItemProvider performance behavior", () => {
+  const projectPath = "/project";
+
+  test("reuses a tag candidate list and refreshes it after an update", async () => {
+    const provider = new TyranoCompletionItemProvider();
+    const providerAny = provider as unknown as TestableCompletionProvider;
+    const suggestions: Record<string, { name: string; description: string }> = {
+      p: { name: "p", description: "before update" },
+    };
+    let suggestionVersion = 1;
+    providerAny.infoWs = {
+      suggestions: new Map([[projectPath, suggestions]]),
+      getSuggestionVersion: () => suggestionVersion,
+    };
+
+    const document = createMockDocument("p");
+    const position = new vscode.Position(0, 1);
+    const firstResult = await providerAny.completionTag(
+      projectPath,
+      document,
+      position,
+    );
+    const secondResult = await providerAny.completionTag(
+      projectPath,
+      document,
+      position,
+    );
+
+    assert.ok(Array.isArray(firstResult));
+    assert.strictEqual(
+      firstResult,
+      secondResult,
+      "unchanged suggestions should reuse the same candidate list",
+    );
+
+    suggestions.p.description = "after update";
+    suggestions.jump = { name: "jump", description: "jump" };
+    suggestionVersion += 1;
+    const refreshedResult = await providerAny.completionTag(
+      projectPath,
+      document,
+      position,
+    );
+
+    assert.ok(Array.isArray(refreshedResult));
+    assert.notStrictEqual(refreshedResult, firstResult);
+    assert.ok(
+      refreshedResult
+        .map((item: vscode.CompletionItem) => getCompletionLabel(item))
+        .includes("jump"),
+    );
+    assert.ok(
+      (
+        (refreshedResult[0] as vscode.CompletionItem)
+          .documentation as vscode.MarkdownString
+      ).value.includes("after update"),
+    );
+
+    delete suggestions.p;
+    delete suggestions.jump;
+    suggestionVersion += 1;
+    const removedResult = await providerAny.completionTag(
+      projectPath,
+      document,
+      position,
+    );
+
+    assert.deepStrictEqual(removedResult, []);
+  });
+
+  test("preserves tag insertion styles while caching each style separately", async () => {
+    const provider = new TyranoCompletionItemProvider();
+    const providerAny = provider as unknown as TestableCompletionProvider;
+    const suggestions = {
+      p: { name: "p", description: "paragraph" },
+    };
+    providerAny.infoWs = {
+      suggestions: new Map([[projectPath, suggestions]]),
+      getSuggestionVersion: () => 1,
+    };
+
+    const normalResult = await providerAny.completionTag(
+      projectPath,
+      createMockDocument("p"),
+      new vscode.Position(0, 1),
+    );
+    const bracketResult = await providerAny.completionTag(
+      projectPath,
+      createMockDocument("[p"),
+      new vscode.Position(0, 2),
+    );
+    const atResult = await providerAny.completionTag(
+      projectPath,
+      createMockDocument("@p"),
+      new vscode.Position(0, 2),
+    );
+
+    assert.ok(Array.isArray(normalResult));
+    assert.ok(Array.isArray(bracketResult));
+    assert.ok(Array.isArray(atResult));
+    const inputType = vscode.workspace
+      .getConfiguration()
+      .get<string>("TyranoScript syntax.completionTag.inputType");
+    assert.strictEqual(
+      getInsertText(normalResult[0]),
+      inputType === "@" ? "@p $0" : "[p $0]",
+    );
+    assert.strictEqual(getInsertText(bracketResult[0]), "p $0");
+    assert.strictEqual(getInsertText(atResult[0]), "p $0");
+    assert.notStrictEqual(normalResult, bracketResult);
+    assert.notStrictEqual(bracketResult, atResult);
+  });
+
+  test("does not mutate chara_part suggestions while adding dynamic parts", async () => {
+    const provider = new TyranoCompletionItemProvider();
+    const providerAny = provider as unknown as TestableCompletionProvider;
+    const baseSuggestion = {
+      name: "chara_part",
+      description: "character part",
+      parameters: [
+        {
+          name: "name",
+          description: "character name",
+          required: true,
+        },
+      ],
+    };
+    providerAny.infoWs = {
+      suggestions: new Map([[projectPath, { chara_part: baseSuggestion }]]),
+      characterMap: new Map([
+        [
+          projectPath,
+          [
+            {
+              name: "hero",
+              layer: new Map([
+                ["eye", []],
+                ["mouth", []],
+              ]),
+            },
+          ],
+        ],
+      ]),
+    };
+
+    const result = await providerAny.completionParameter(
+      "chara_part",
+      {},
+      projectPath,
+      "hero",
+      createMockDocument("[chara_part "),
+      new vscode.Position(0, 12),
+    );
+
+    assert.ok(Array.isArray(result));
+    const labels = result.map((item: vscode.CompletionItem) =>
+      getCompletionLabel(item),
+    );
+    assert.ok(labels.includes("eye"));
+    assert.ok(labels.includes("mouth"));
+    assert.deepStrictEqual(
+      baseSuggestion.parameters.map((parameter) => parameter.name),
+      ["name"],
+    );
+  });
+});


### PR DESCRIPTION
## 概要

Closes #416

タグ補完を繰り返し実行した際の応答速度を改善します。

## 原因

- 補完要求ごとに全タグ候補から `CompletionItem`、`SnippetString`、`MarkdownString` を作り直していた
- プロジェクトルートを補完ごとに同期的なディレクトリ走査で解決していた
- パラメータ補完で候補データ全体を `structuredClone` していた

## 変更内容

- タグ候補を候補データの更新世代・入力書式ごとに遅延キャッシュ
- タグの追加・削除・再初期化時にキャッシュを無効化
- 既知プロジェクトのルートを探索上限にし、より近い `index.html` の存在確認だけでルートを解決
- 拡張起動後に追加された入れ子プロジェクトを親プロジェクトより優先
- パラメータ補完の全体コピーを除去し、`chara_part` の動的候補を非破壊で追加
- 補完キャッシュ、書式、候補削除、プロジェクトルート解決の回帰テストを追加

## 検証

- `npm run compile`
- 変更対象ファイルの ESLint（エラーなし、既存の複雑度警告のみ）
- GitHub Actions の Extension Tests