### PR TITLE
TyranoScript以外でのエラー通知を抑制し、自動補完を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "tyranosyntax" extension will be documented in this f
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [3.2.1] 2026-07-13
+
+- TyranoScriptと関係のないフォルダを開いた際に、TyranoScriptプロジェクトが見つからない旨のエラーが表示される不具合を修正しました。
+
 ## [3.2.0] 2026-06-11
 
 - .ksファイルのコードフォーマット機能を追加しました。VS Code標準の「ドキュメントのフォーマット」（`Shift+Alt+F`）で以下の整形が行われます。

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/orukRed/tyranosyntax"
   },
   "icon": "images/icon.png",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "engines": {
     "vscode": "^1.79.1"
   },

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "onLanguage:tyrano",
-    "onStartupFinished"
+    "onLanguage:tyrano"
   ],
   "comment": "tyranoscriptのファイル開いた時extension.tsを起動",
   "main": "./out/extension.js",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,11 @@
               "タグの予測変換をするとき、@から始まるタグを出力します。"
             ]
           },
+          "TyranoScript syntax.completion.autoTrigger": {
+            "type": "boolean",
+            "default": true,
+            "description": "文字入力時にタグやパラメータなどの補完候補を自動表示します。無効にした場合もCtrl + Spaceで手動表示できます。"
+          },
           "TyranoScript syntax.outline.blockComment": {
             "type": "boolean",
             "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -641,13 +641,14 @@ export function activate(context: ExtensionContext) {
 
           TyranoLogger.print("TyranoScript syntax initialize end");
 
-          //エラーポップアップ
-          if (infoWs.getTyranoScriptProjectRootPaths().length === 0) {
-            vscode.window.showErrorMessage(
+          // ティラノプロジェクトでない場合は、通知せずログにのみ記録する
+          const projectRootPaths = infoWs.getTyranoScriptProjectRootPaths();
+          if (projectRootPaths.length === 0) {
+            TyranoLogger.print(
               `TyranoScriptのプロジェクトが見つかりませんでした。一部機能が使用できません。`,
             );
           }
-          infoWs.getTyranoScriptProjectRootPaths().forEach((element) => {
+          projectRootPaths.forEach((element) => {
             vscode.window.showInformationMessage(
               `${element.split(infoWs.pathDelimiter).pop()}の初期化が完了しました。`,
             );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,6 @@ import { LanguageClient } from "vscode-languageclient/node";
 import { TyranoCreateTagByShortcutKey } from "./subscriptions/TyranoCreateTagByShortcutKey";
 import { TyranoHoverProvider } from "./subscriptions/TyranoHoverProvider";
 import { TyranoOutlineProvider } from "./subscriptions/TyranoOutlineProvider";
-import { TyranoCompletionItemProvider } from "./subscriptions/TyranoCompletionItemProvider";
 import { TyranoDiagnostic } from "./subscriptions/TyranoDiagnostic";
 import { ErrorLevel, TyranoLogger } from "./TyranoLogger";
 import { InformationWorkSpace } from "./InformationWorkSpace";
@@ -40,6 +39,7 @@ import { MacroTreeProvider } from "./subscriptions/sidebar/MacroTreeProvider";
 import { SidebarRefresher } from "./subscriptions/sidebar/SidebarRefresher";
 import { UsageIndexer } from "./subscriptions/sidebar/UsageIndexer";
 import { VariableTreeProvider } from "./subscriptions/sidebar/VariableTreeProvider";
+import { registerTyranoCompletionItemProvider } from "./subscriptions/TyranoCompletionRegistration";
 
 const TYRANO_MODE = { scheme: "file", language: "tyrano" };
 // Delay in milliseconds to wait for VS Code's file system to sync after external file changes (e.g., git operations)
@@ -324,11 +324,7 @@ export function activate(context: ExtensionContext) {
           );
           TyranoLogger.print("TyranoOutlineProvider activate");
           context.subscriptions.push(
-            vscode.languages.registerCompletionItemProvider(
-              TYRANO_MODE,
-              new TyranoCompletionItemProvider(),
-              ".",
-            ),
+            registerTyranoCompletionItemProvider(),
           );
           TyranoLogger.print("TyranoCompletionItemProvider activate");
 

--- a/src/subscriptions/TyranoCompletionItemProvider.ts
+++ b/src/subscriptions/TyranoCompletionItemProvider.ts
@@ -5,6 +5,7 @@ import { Parser } from "../Parser";
 import { ErrorLevel, TyranoLogger } from "../TyranoLogger";
 import { VariableData } from "../defineData/VariableData";
 import * as fs from "fs";
+import { shouldTriggerCompletionAutomatically } from "./TyranoCompletionTrigger";
 
 type SuggestionsMiniumByTag = {
   [tag: string]: {
@@ -108,7 +109,7 @@ export class TyranoCompletionItemProvider
     document: vscode.TextDocument,
     position: vscode.Position,
     _token: vscode.CancellationToken,
-    _context: vscode.CompletionContext,
+    context: vscode.CompletionContext,
   ): Promise<
     | vscode.CompletionItem[]
     | vscode.CompletionList<vscode.CompletionItem>
@@ -116,11 +117,21 @@ export class TyranoCompletionItemProvider
     | undefined
   > {
     try {
+      const lineText = document.lineAt(position.line).text;
+      if (
+        context.triggerKind === vscode.CompletionTriggerKind.TriggerCharacter &&
+        !shouldTriggerCompletionAutomatically(
+          lineText.substring(0, position.character),
+          context.triggerCharacter,
+        )
+      ) {
+        return undefined;
+      }
+
       const projectPath = await this.infoWs.getProjectPathByFilePath(
         document.fileName,
       );
       //カーソル付近のタグデータを取得
-      const lineText = document.lineAt(position.line).text;
       const parsedData = this.parser.parseText(lineText);
       const tagIndex = this.parser.getIndex(parsedData, position.character);
 

--- a/src/subscriptions/TyranoCompletionRegistration.ts
+++ b/src/subscriptions/TyranoCompletionRegistration.ts
@@ -1,0 +1,47 @@
+import * as vscode from "vscode";
+import { TyranoCompletionItemProvider } from "./TyranoCompletionItemProvider";
+import {
+  AUTO_COMPLETION_SETTING,
+  getCompletionTriggerCharacters,
+} from "./TyranoCompletionTrigger";
+
+const TYRANO_MODE: vscode.DocumentSelector = {
+  scheme: "file",
+  language: "tyrano",
+};
+
+/**
+ * 補完プロバイダーを登録し、自動補完設定の変更時にトリガー文字を更新する。
+ */
+export function registerTyranoCompletionItemProvider(): vscode.Disposable {
+  let providerRegistration: vscode.Disposable | undefined;
+
+  const registerProvider = () => {
+    providerRegistration?.dispose();
+
+    const autoTriggerEnabled = vscode.workspace
+      .getConfiguration()
+      .get<boolean>(AUTO_COMPLETION_SETTING, true);
+    providerRegistration = vscode.languages.registerCompletionItemProvider(
+      TYRANO_MODE,
+      new TyranoCompletionItemProvider(),
+      ...getCompletionTriggerCharacters(autoTriggerEnabled),
+    );
+  };
+
+  registerProvider();
+  const configurationRegistration = vscode.workspace.onDidChangeConfiguration(
+    (event) => {
+      if (event.affectsConfiguration(AUTO_COMPLETION_SETTING)) {
+        registerProvider();
+      }
+    },
+  );
+
+  return {
+    dispose: () => {
+      configurationRegistration.dispose();
+      providerRegistration?.dispose();
+    },
+  };
+}

--- a/src/subscriptions/TyranoCompletionTrigger.ts
+++ b/src/subscriptions/TyranoCompletionTrigger.ts
@@ -1,0 +1,68 @@
+export const AUTO_COMPLETION_SETTING =
+  "TyranoScript syntax.completion.autoTrigger";
+
+const TAG_NAME_TRIGGER_CHARACTERS = [
+  ..."abcdefghijklmnopqrstuvwxyz",
+  ..."ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+  ..."0123456789",
+  "_",
+] as const;
+
+export const AUTO_COMPLETION_TRIGGER_CHARACTERS = [
+  ...TAG_NAME_TRIGGER_CHARACTERS,
+  ".",
+  "[",
+  "@",
+  "#",
+  "*",
+  " ",
+  '"',
+] as const;
+
+export function getCompletionTriggerCharacters(
+  autoTriggerEnabled: boolean,
+): string[] {
+  return autoTriggerEnabled ? [...AUTO_COMPLETION_TRIGGER_CHARACTERS] : [];
+}
+
+/**
+ * 自動補完では、本文の入力を妨げないTyranoScript固有の文脈だけを対象にする。
+ * Ctrl+Spaceによる手動補完ではこの判定を行わない。
+ */
+export function shouldTriggerCompletionAutomatically(
+  linePrefix: string,
+  triggerCharacter: string | undefined,
+): boolean {
+  const lastOpenBracket = linePrefix.lastIndexOf("[");
+  const lastCloseBracket = linePrefix.lastIndexOf("]");
+  const isInsideBracketTag = lastOpenBracket > lastCloseBracket;
+  const isInsideAtTag = /^\s*@/.test(linePrefix);
+  const isInsideTag = isInsideBracketTag || isInsideAtTag;
+
+  
+  switch (triggerCharacter) {
+    case "[":
+      return true;
+    case "@":
+      return /^\s*@$/.test(linePrefix);
+    case "#":
+      return /^\s*#$/.test(linePrefix);
+    case "*":
+      return /^\s*\*$/.test(linePrefix);
+    case " ":
+    case '"':
+      return isInsideTag;
+    case ".":
+      return /(?:^|[^\w])&?(?:f|sf|tf|mp)(?:\.[^\s.[\]"=]*)*\.$/.test(
+        linePrefix,
+      );
+    default:
+      return (
+        triggerCharacter !== undefined &&
+        TAG_NAME_TRIGGER_CHARACTERS.includes(
+          triggerCharacter as (typeof TAG_NAME_TRIGGER_CHARACTERS)[number],
+        ) &&
+        /^\s*[A-Za-z0-9_]+$/.test(linePrefix)
+      );
+  }
+}

--- a/src/test/suite/subscriptions/TyranoCompletionTrigger.test.ts
+++ b/src/test/suite/subscriptions/TyranoCompletionTrigger.test.ts
@@ -1,0 +1,107 @@
+import * as assert from "assert";
+import {
+  AUTO_COMPLETION_TRIGGER_CHARACTERS,
+  getCompletionTriggerCharacters,
+  shouldTriggerCompletionAutomatically,
+} from "../../../subscriptions/TyranoCompletionTrigger";
+
+suite("TyranoCompletionTrigger", () => {
+  suite("getCompletionTriggerCharacters", () => {
+    test("自動補完が有効ならトリガー文字を返す", () => {
+      const triggerCharacters = getCompletionTriggerCharacters(true);
+      assert.deepStrictEqual(triggerCharacters, [
+        ...AUTO_COMPLETION_TRIGGER_CHARACTERS,
+      ]);
+      assert.ok(triggerCharacters.includes("b"));
+      assert.ok(triggerCharacters.includes("g"));
+    });
+
+    test("自動補完が無効ならトリガー文字を返さない", () => {
+      assert.deepStrictEqual(getCompletionTriggerCharacters(false), []);
+    });
+  });
+
+  suite("shouldTriggerCompletionAutomatically", () => {
+    test("タグ開始文字では自動補完する", () => {
+      assert.strictEqual(shouldTriggerCompletionAutomatically("[", "["), true);
+      assert.strictEqual(
+        shouldTriggerCompletionAutomatically("  @", "@"),
+        true,
+      );
+    });
+
+    test("行頭でタグ名だけを入力した場合も自動補完する", () => {
+      assert.strictEqual(shouldTriggerCompletionAutomatically("b", "b"), true);
+      assert.strictEqual(shouldTriggerCompletionAutomatically("bg", "g"), true);
+      assert.strictEqual(
+        shouldTriggerCompletionAutomatically("  3d_", "_"),
+        true,
+      );
+    });
+
+    test("本文途中の英数字では自動補完しない", () => {
+      assert.strictEqual(
+        shouldTriggerCompletionAutomatically("本文b", "b"),
+        false,
+      );
+      assert.strictEqual(
+        shouldTriggerCompletionAutomatically("text b", "b"),
+        false,
+      );
+    });
+
+    test("タグ内の空白と引用符では自動補完する", () => {
+      assert.strictEqual(
+        shouldTriggerCompletionAutomatically("[bg ", " "),
+        true,
+      );
+      assert.strictEqual(
+        shouldTriggerCompletionAutomatically('[bg storage="', '"'),
+        true,
+      );
+      assert.strictEqual(
+        shouldTriggerCompletionAutomatically("@bg ", " "),
+        true,
+      );
+    });
+
+    test("本文中の空白と引用符では自動補完しない", () => {
+      assert.strictEqual(
+        shouldTriggerCompletionAutomatically("本文 ", " "),
+        false,
+      );
+      assert.strictEqual(
+        shouldTriggerCompletionAutomatically('本文"', '"'),
+        false,
+      );
+    });
+
+    test("変数のドットでは自動補完する", () => {
+      assert.strictEqual(
+        shouldTriggerCompletionAutomatically('[eval exp="f.', "."),
+        true,
+      );
+      assert.strictEqual(
+        shouldTriggerCompletionAutomatically('[eval exp="sf.user.', "."),
+        true,
+      );
+      assert.strictEqual(
+        shouldTriggerCompletionAutomatically("本文.", "."),
+        false,
+      );
+    });
+
+    test("ラベルとキャラクター名は行頭だけ自動補完する", () => {
+      assert.strictEqual(shouldTriggerCompletionAutomatically(" *", "*"), true);
+      assert.strictEqual(shouldTriggerCompletionAutomatically(" #", "#"), true);
+      assert.strictEqual(
+        shouldTriggerCompletionAutomatically("本文 *", "*"),
+        false,
+      );
+      assert.strictEqual(
+        shouldTriggerCompletionAutomatically("本文 #", "#"),
+        false,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## 概要

- TyranoScriptファイルを開いたときだけ拡張機能を起動し、TyranoScript以外のワークスペースで不要なエラー通知が表示されないようにしました。
- タグ名、パラメータ、変数、ラベル、キャラクター名などの入力時に、文脈に応じて補完候補を自動表示するようにしました。
- 入力時の自動補完を無効化できる設定を追加しました。無効化した場合も、`Ctrl + Space`による手動補完は利用できます。

## 背景

`onStartupFinished` によって、PythonアプリなどTyranoScriptと無関係なフォルダでも拡張機能が起動し、プロジェクトが見つからない旨のエラー通知が表示されていました。

また、TyranoScriptの記述中に補完候補を呼び出しやすくするため、本文入力を妨げない範囲で、TyranoScript固有の文脈に応じて自動補完を開始する仕組みを追加しました。

## 変更内容

### 起動とプロジェクト検出

- `onStartupFinished` を削除し、`onLanguage:tyrano` でのみ起動するように変更
- TyranoScriptプロジェクトが見つからない場合、エラー通知を表示せず出力ログにのみ記録
- プロジェクトルートの検出結果を再利用し、重複した取得を回避

### 入力補完

- タグ、パラメータ、変数、ラベル、キャラクター名の入力に対応したトリガー文字を追加
- TyranoScript固有の文脈だけで自動補完を行う判定を追加
- `TyranoScript syntax.completion.autoTrigger` 設定を追加（既定値: `true`）
- 設定変更時に補完プロバイダーを再登録し、変更を即時反映
- 自動補完のトリガー判定に対するテストを追加

### ドキュメント

- `CHANGELOG.md` の `3.2.2` に、TyranoScript以外のフォルダで表示されるエラー通知の修正を追記

## 確認

- `npm run compile`
- 変更対象のTypeScriptファイルに対するESLint（エラーなし）
- `npm run lint` 全体では、今回未変更の `MacroTablePanel.ts` と既存テストにある2件の既存エラーを確認
